### PR TITLE
Add scan cancel endpoint and update Swift client

### DIFF
--- a/ui/Sources/Services/SentinelAPIClient.swift
+++ b/ui/Sources/Services/SentinelAPIClient.swift
@@ -104,7 +104,7 @@ public struct SentinelAPIClient: Sendable {
 
     /// Request best-effort scan cancellation.
     public func cancelScan() async throws {
-        guard let url = URL(string: "/v1/cancel", relativeTo: baseURL) else { return }
+        guard let url = URL(string: "/v1/scans/cancel", relativeTo: baseURL) else { return }
         let request = authenticatedRequest(url: url, method: "POST")
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { throw APIError.badStatus }


### PR DESCRIPTION
### Motivation
- Provide a dedicated API to request cancellation of an in-progress scan and to reflect cancellation state in the backend via `state.cancel_requested`.
- Mirror UI/Swift client behavior so the frontend can treat `409` (no active scan) as a benign outcome and `202` as an accepted cancel request.
- Ensure cancellation is synchronized with existing scan locking and task lifecycle to avoid races.
- Maintain token-protected access to scan control via `verify_sensitive_token`.

### Description
- Added a new POST endpoint `POST /scans/cancel` in `core/server/routers/scans.py` that acquires `state.scan_lock`, returns `409` when no active scan is running, otherwise sets `state.cancel_requested` and calls `state.active_scan_task.cancel()` then returns `202`.
- Protected the new endpoint with the same dependency `verify_sensitive_token` used by other scan control routes.
- Updated the Swift client `SentinelAPIClient.cancelScan()` in `ui/Sources/Services/SentinelAPIClient.swift` to call `/v1/scans/cancel` and treat `202` and `409` as successful outcomes.
- Changes are limited to `core/server/routers/scans.py` and `ui/Sources/Services/SentinelAPIClient.swift`.

### Testing
- No automated tests were executed for this change.
- Basic static inspection and local edits were performed; runtime behavior should be validated in integration or CI before production deployment.
- Developers should exercise `startScan` followed by `cancelScan` and observe `scan_state` transitions and the returned HTTP codes.
- Swift UI should be tested to confirm it treats `409` as an expected "already stopped" response and handles `202` as accepted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c2f0c02c832f851894d8afeae4a2)