### PR TITLE
Stabilize scan lifecycle: SSE reconnection, backend preflight, and pressure-graph hydration

### DIFF
--- a/core/cortex/events.py
+++ b/core/cortex/events.py
@@ -941,8 +941,17 @@ class EventBus:
             payload["scan_id"] = scan_id
         self.emit(GraphEvent(type=EventType.TOOL_STARTED, payload=payload, scan_id=scan_id, source="engine", priority=0))
 
-    def emit_tool_completed(self, tool: str, exit_code: int, findings_count: int, scan_id: Optional[str] = None) -> None:
+    def emit_tool_completed(
+        self,
+        tool: str,
+        exit_code: int,
+        findings_count: int,
+        scan_id: Optional[str] = None,
+        error: Optional[Dict[str, Any]] = None,
+    ) -> None:
         payload: Dict[str, Any] = {"tool": tool, "exit_code": exit_code, "findings_count": findings_count}
+        if error:
+            payload["error"] = error
         if scan_id:
             payload["scan_id"] = scan_id
         self.emit(GraphEvent(type=EventType.TOOL_COMPLETED, payload=payload, scan_id=scan_id, source="engine", priority=0))

--- a/core/errors.py
+++ b/core/errors.py
@@ -256,6 +256,21 @@ class SentinelError(Exception):
         return cls(code, message, details, http_status)
 
 
+class ToolError(SentinelError):
+    """
+    Structured error for tool execution failures.
+    Preserves tool name, exit code, and stderr to retain context across layers.
+    """
+
+    def __init__(self, tool: str, exit_code: int, stderr: str, message: Optional[str] = None):
+        details = {"tool": tool, "exit_code": exit_code, "stderr": stderr}
+        super().__init__(
+            ErrorCode.TOOL_EXEC_FAILED,
+            message or f"Tool {tool} failed with exit code {exit_code}",
+            details=details,
+        )
+
+
 # ============================================================================
 # Critical Security Exceptions (Halt System Startup)
 # ============================================================================
@@ -423,4 +438,11 @@ def handle_error(error: Exception, context: Optional[str] = None) -> SentinelErr
 # Module-Level Exports
 # ============================================================================
 
-__all__ = ["ErrorCode", "SentinelError", "SentinelSecurityError", "CriticalSecurityBreach", "handle_error"]
+__all__ = [
+    "ErrorCode",
+    "SentinelError",
+    "ToolError",
+    "SentinelSecurityError",
+    "CriticalSecurityBreach",
+    "handle_error",
+]

--- a/ui/Sources/Models/FindingModels.swift
+++ b/ui/Sources/Models/FindingModels.swift
@@ -263,8 +263,35 @@ public struct AIStatusResponse: Decodable {
 
 // MARK: - Errors
 
-public enum APIError: Error {
+public enum APIError: Error, Equatable {
     case badStatus
     case unauthorized
     case tokenNotFound
+    case toolFailed(tool: String, exitCode: Int, stderr: String)
+    case scanTimeout(duration: TimeInterval)
+    case connectionRefused
+    case serverError(code: String, message: String)
+
+    var userMessage: String {
+        switch self {
+        case .badStatus:
+            return "API Error: unexpected server response."
+        case .unauthorized:
+            return "Unauthorized. Please restart Sentinel to refresh credentials."
+        case .tokenNotFound:
+            return "Authentication token missing. Restart the backend to regenerate."
+        case .toolFailed(let tool, let exitCode, _):
+            return "Tool '\(tool)' failed (exit code \(exitCode)). Check installation and permissions."
+        case .scanTimeout(let duration):
+            return "Scan exceeded timeout of \(Int(duration))s. Target may be slow or unreachable."
+        case .connectionRefused:
+            return "Cannot connect to backend. Make sure Sentinel is running."
+        case .serverError(_, let message):
+            return message
+        }
+    }
+}
+
+extension APIError: LocalizedError {
+    public var errorDescription: String? { userMessage }
 }

--- a/ui/Sources/Services/EventStreamClient.swift
+++ b/ui/Sources/Services/EventStreamClient.swift
@@ -197,6 +197,13 @@ public class EventStreamClient: ObservableObject {
         }
     }
 
+    /// Force reconnect by cancelling the current task and starting a new one.
+    func reconnectNow() {
+        disconnect()
+        reconnectAttempt = 0
+        connect()
+    }
+
     /// Stop consuming and disconnect
     nonisolated func disconnect() {
         Task { @MainActor in
@@ -323,6 +330,10 @@ public class EventStreamClient: ObservableObject {
                     print("[EventStreamClient] Raw JSON: \(json)")
                 }
             }
+        }
+
+        if !Task.isCancelled {
+            isConnected = false
         }
     }
 

--- a/ui/Tests/Sources/TestRunner/main.swift
+++ b/ui/Tests/Sources/TestRunner/main.swift
@@ -19,6 +19,51 @@ import SentinelForgeUI
 struct TestRunner {
     static func main() async {
         print("--- Starting Swift Client Test ---")
+
+        func assert(_ condition: @autoclosure () -> Bool, _ message: String) {
+            if !condition() {
+                print("    FAILED: \(message)")
+                exit(1)
+            }
+        }
+
+        // 0. Test API error parsing
+        let testURL = URL(string: "http://localhost")!
+        let errorResponse = HTTPURLResponse(url: testURL, statusCode: 500, httpVersion: nil, headerFields: nil)
+        let toolErrorPayload: [String: Any] = [
+            "code": "TOOL_002",
+            "message": "Tool failed",
+            "details": ["tool": "nmap", "exit_code": 124, "stderr": "timeout"],
+        ]
+        let scanTimeoutPayload: [String: Any] = [
+            "code": "SCAN_003",
+            "message": "Scan timed out",
+            "details": ["duration": 120],
+        ]
+
+        if let data = try? JSONSerialization.data(withJSONObject: toolErrorPayload) {
+            let error = SentinelAPIClient.parseAPIError(data: data, response: errorResponse)
+            switch error {
+            case .toolFailed(let tool, let exitCode, let stderr):
+                assert(tool == "nmap", "Expected tool name to be nmap")
+                assert(exitCode == 124, "Expected exit code 124")
+                assert(stderr == "timeout", "Expected stderr to be timeout")
+            default:
+                print("    FAILED: Expected toolFailed error")
+                exit(1)
+            }
+        }
+
+        if let data = try? JSONSerialization.data(withJSONObject: scanTimeoutPayload) {
+            let error = SentinelAPIClient.parseAPIError(data: data, response: errorResponse)
+            switch error {
+            case .scanTimeout(let duration):
+                assert(duration == 120, "Expected scan timeout duration to be 120")
+            default:
+                print("    FAILED: Expected scanTimeout error")
+                exit(1)
+            }
+        }
         
         let client = SentinelAPIClient()
         


### PR DESCRIPTION
### **User description**
### Motivation
- Reduce scan state desynchronization by ensuring UI scan state is derived from backend lifecycle events only.
- Make the SSE event stream resilient to transient disconnects so active scans remain visible in the UI.
- Prevent frequent backend startup failures by validating runtime, port availability and required tools before launching.
- Ensure the pressure graph populates reliably on load even if store signals were missed at startup.

### Description
- HelixAppState: removed optimistic writes to `isScanRunning` in `startScan` and `cancelScan` and rely on event-driven lifecycle updates; added a subscriber to `eventClient.$isConnected` to trigger reconnection when disconnected during an active scan (calls `reconnectNow`).
- EventStreamClient: added `reconnectNow()` to forcibly restart the connection loop, mark `isConnected = false` when the consumer loop exits, and preserved sequence/epoch handling so reconnections resume from the last sequence.
- BackendManager: added `validateEnvironment(...)` preflight which checks Python executable presence, port `8765` availability, and required system tools (`nmap`, `httpx`), integrates into startup to fail fast with clear diagnostics, and injected `Network`-based port check and PATH normalization helpers.
- PressureGraphManager: hydrate graph from issue store on load with `_hydrate_from_stores()` and auto-detect crown jewels with `_auto_detect_crown_jewels()` plus `_ensure_crown_jewels()` to trigger `recompute_pressure()` when appropriate, and call hydration even when DB snapshot is empty.

### Testing
- No automated tests were executed as part of this change (none requested); changes were implemented and compiled locally in the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697049fcc0b0832fb1d51155c2e0140d)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Stabilize scan lifecycle by removing optimistic state writes and relying on event-driven updates

- Add SSE reconnection logic to handle transient disconnects during active scans

- Implement backend preflight validation for Python, port availability, and system tools

- Hydrate pressure graph from issue store on load and auto-detect crown jewels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HelixAppState"] -->|removes optimistic writes| B["Event-driven scan state"]
  A -->|monitors connection| C["EventStreamClient"]
  C -->|triggers reconnect| D["reconnectNow"]
  E["BackendManager"] -->|validates| F["Environment Preflight"]
  F -->|checks| G["Python, Port 8765, System Tools"]
  H["PressureGraphManager"] -->|hydrates on load| I["Issue Store"]
  I -->|auto-detects| J["Crown Jewels"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manager.py</strong><dd><code>Hydrate pressure graph and auto-detect crown jewels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

core/data/pressure_graph/manager.py

<ul><li>Added <code>_hydrate_from_stores()</code> method to pull current data from issue <br>store when signals are missed at startup<br> <li> Implemented <code>_auto_detect_crown_jewels()</code> to identify critical assets <br>with value >= 8.0<br> <li> Added <code>_ensure_crown_jewels()</code> to automatically populate crown jewels <br>when none are set<br> <li> Integrated hydration calls in <code>_load_state()</code> and <code>_on_issues_changed()</code> <br>to ensure graph consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Jbase16/sentinel/pull/23/files#diff-a20f4115d47b0b6edfdfc78ebba150b7c1af66ec323305f687ff67c073e2e46d">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BackendManager.swift</strong><dd><code>Add environment preflight validation for startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/Sources/Services/BackendManager.swift

<ul><li>Added <code>Network</code> framework import for port availability checking<br> <li> Added <code>requiredSystemTools</code> list containing <code>nmap</code> and <code>httpx</code><br> <li> Implemented <code>validateEnvironment()</code> method to check Python executable, <br>port 8765 availability, and required system tools<br> <li> Added <code>buildToolSearchPath()</code> to construct comprehensive PATH for tool <br>discovery<br> <li> Added <code>isPortAvailable()</code> using NWListener to check if port 8765 is <br>available<br> <li> Added <code>isToolInstalled()</code> to verify system tools are in PATH<br> <li> Integrated preflight validation into startup flow before running other <br>checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Jbase16/sentinel/pull/23/files#diff-7ea421cd23a4666f0d952e1e51235bc3723a180d60e5eb5f27b0642def6f0dd0">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EventStreamClient.swift</strong><dd><code>Add forced reconnection and connection state tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ui/Sources/Services/EventStreamClient.swift

<ul><li>Added <code>reconnectNow()</code> method to forcibly restart connection by <br>cancelling current task and resetting reconnect attempt counter<br> <li> Added logic to mark <code>isConnected = false</code> when consumer loop exits to <br>ensure accurate connection state</ul>


</details>


  </td>
  <td><a href="https://github.com/Jbase16/sentinel/pull/23/files#diff-e7675e29eab9ccdcd2eaac867345e596a0297f082cea9d45c127ab10e4075742">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HelixAppState.swift</strong><dd><code>Remove optimistic state writes and add reconnection logic</code></dd></summary>
<hr>

ui/Sources/Models/HelixAppState.swift

<ul><li>Removed optimistic writes to <code>isScanRunning</code> in <code>startScan()</code> method<br> <li> Removed optimistic writes to <code>isScanRunning</code> in <code>cancelScan()</code> method<br> <li> Added subscriber to <code>eventClient.$isConnected</code> to trigger reconnection <br>when disconnected during active scan<br> <li> Reconnection includes 2-second delay before calling <code>reconnectNow()</code> to <br>allow graceful recovery</ul>


</details>


  </td>
  <td><a href="https://github.com/Jbase16/sentinel/pull/23/files#diff-0d804959e98c28f03f0febc9708f6b205a690176c75aac3c196196f0b79d68ec">+13/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Reliable scan state tracking: UI no longer sets scan state optimistically — scan running/stopped is derived from backend lifecycle events to avoid false statuses across reconnects and sessions.
- SSE resiliency during scans: event stream client now forces a reconnect when disconnected during an active scan (with a 2s delay and reset of reconnect attempts), reducing transient disconnect impact on ongoing scans.
- Force-reconnect API on client: EventStreamClient.reconnectNow() added to immediately restart the SSE consumer loop and resume from the last event sequence.
- Backend preflight checks: backend startup now validates Python runtime, port 8765 availability, and presence of required tools (nmap, httpx) and fails fast with diagnostic messages instead of failing during runtime.
- PATH and port handling improvements: PATH normalization and a Network-based port-availability check (NWListener) were added to make tooling discovery and port validation more robust on startup.
- Pressure graph hydration and crown-jewel detection: pressure graph now hydrates from the issue store on load (including empty snapshots), auto-detects/populates crown-jewel assets (asset_value >= 8.0), and triggers recompute to ensure the graph is populated even if backend signals were missed at startup.
- Richer tool/scan error surfacing: tool execution failures are captured, exposed through a new ToolError type and included in scan/tool-completed events and API error parsing, enabling clearer user-facing error messages.
- API client error mapping and client-side error tests: API error parsing centralised to produce richer, actionable APIError variants (including tool failures and scan timeouts); unit tests added to validate parsing.

Risk & Rollback

Primary risk: The event-stream reconnection and event-driven scan state removal of optimistic UI toggles could introduce race conditions (duplicate or missing lifecycle events) during rapid connect/disconnect or concurrent user cancellations, causing transient incorrect UI state or duplicate log entries.

Safe rollback: Revert the HelixAppState connectivity subscriber and the EventStreamClient.reconnectNow changes to restore optimistic isScanRunning updates in startScan/cancelScan; this returns UI to previous behavior while keeping backend preflight and pressure-graph hydration changes (they can be rolled independently if desired).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->