### PR TITLE
fix(ghost): make capture usable end-to-end + ship G5 cross-principal diff

### DIFF
--- a/core/ghost/lazarus.py
+++ b/core/ghost/lazarus.py
@@ -106,92 +106,72 @@ class LazarusEngine:
     
     async def _process_async(self, flow: http.HTTPFlow):
         """
-        Process JS de-obfuscation asynchronously.
-        Uses asyncio.to_thread to avoid blocking the event loop.
-        
-        TRINITY OF HARDENING - Chapter 18: Lazarus Spectral Reconstructor
-        ───────────────────────────────────────────────────────────────────
-        1. De-obfuscate JS to reveal hidden API routes
-        2. Emit FINDING_DISCOVERED events for each discovered route
-        3. Generate Shadow API Client for pre-flight attack simulation
+        PASSIVELY analyze JavaScript for referenced API routes.
+
+        ⚠️  INVARIANT: Ghost is a *passive* interception proxy. This method
+        MUST NOT modify ``flow.response`` in any way. The browser must receive
+        the site's bytes exactly as the server sent them.
+
+        A previous version replaced the entire JS body with a truncated,
+        LLM-"de-obfuscated" rewrite (and, due to an async bug, often with the
+        string repr of an un-awaited coroutine). That corrupted every in-bounds
+        script: pages rendered and scrolled but all click handlers were dead.
+        We now read the response read-only, mine route strings with static
+        regexes over the FULL original code, and emit findings off to the side.
+        De-obfuscation for human analysis, if ever wanted, must happen on a
+        copy in a dedicated viewer — never on the live flow.
         """
         from core.cortex.events import get_event_bus, GraphEvent, GraphEventType
-        
+
         try:
             original_code = flow.response.text
             if not original_code:
                 return
-            
+
             code_hash = hashlib.sha256(original_code.encode()).hexdigest()
             url = flow.request.pretty_url
-            
-            # Check cache first (fast path)
+
+            # Dedup: only mine each distinct script once per run.
             if code_hash in self.cache:
-                flow.response.text = self.cache[code_hash]
-                flow.response.headers["X-Lazarus-Cache"] = "HIT"
-                logger.debug(f"[Lazarus] Cache hit for {code_hash[:8]}")
                 return
-            
-            # Mark as processing to prevent duplicates
-            self._processing.add(code_hash)
-            
-            try:
-                # Run AI in thread pool to avoid blocking
-                clean_code = await asyncio.to_thread(
-                    self.ai.deobfuscate_code,
-                    original_code[:self.max_context_chars]
+            self.cache[code_hash] = code_hash  # marker only; we never serve this
+
+            # Static extraction over the ORIGINAL, full code — no LLM call, no
+            # truncation, no write-back. Route strings (fetch/axios/xhr) survive
+            # minification, so regexes are sufficient and side-effect free.
+            routes = self._extract_api_routes(original_code)
+            if not routes:
+                return
+
+            event_bus = get_event_bus()
+            for route in routes:
+                event_bus.emit(GraphEvent(
+                    type=GraphEventType.FINDING_CREATED,
+                    payload={
+                        "finding_id": hashlib.sha256(
+                            f"{url}:{route['method']}:{route['path']}".encode()
+                        ).hexdigest()[:32],
+                        "tool": "lazarus",
+                        # INFO, not MEDIUM: an API route referenced in a JS
+                        # bundle is an observation, not a vulnerability. The
+                        # old MEDIUM severity flooded the findings store and
+                        # polluted AI summaries.
+                        "severity": "INFO",
+                        "title": f"API route referenced in JS: {route['method']} {route['path']}",
+                        "target": url,
+                    }
+                ))
+                logger.debug(f"[Lazarus] route (passive): {route['method']} {route['path']}")
+
+            shadow_client = self._generate_shadow_client(routes, url)
+            if shadow_client:
+                self._shadow_clients[code_hash] = shadow_client
+                logger.info(
+                    f"[Lazarus] mined {len(routes)} route(s) from {url} (response untouched)"
                 )
-                
-                # Fallback if AI fails
-                if not clean_code:
-                    logger.warning(f"[Lazarus] AI returned empty for {code_hash[:8]}")
-                    clean_code = original_code
-                else:
-                    # Add watermark
-                    clean_code = f"// [Lazarus] De-obfuscated by Sentinel\n{clean_code}"
-                    
-                    # ═════════════════════════════════════════════════════════
-                    # SPECTRAL ANALYSIS: Extract hidden API routes
-                    # ═════════════════════════════════════════════════════════
-                    routes = self._extract_api_routes(clean_code)
-                    event_bus = get_event_bus()
-                    
-                    for route in routes:
-                        # Emit FINDING_CREATED for each hidden route
-                        event_bus.emit(GraphEvent(
-                            type=GraphEventType.FINDING_CREATED,
-                            payload={
-                                "finding_id": hashlib.sha256(f"{url}:{route['method']}:{route['path']}".encode()).hexdigest()[:32],
-                                "tool": "lazarus",
-                                "severity": "MEDIUM",
-                                "title": f"Hidden API route discovered: {route['method']} {route['path']}",
-                                "target": url
-                            }
-                        ))
-                        logger.info(f"[Lazarus] Discovered hidden route: {route['method']} {route['path']}")
-                    
-                    # Generate Shadow API Client if routes found
-                    if routes:
-                        shadow_client = self._generate_shadow_client(routes, url)
-                        if shadow_client:
-                            # Store shadow client for Strategos
-                            self._shadow_clients[code_hash] = shadow_client
-                            logger.info(f"[Lazarus] Generated Shadow Client with {len(routes)} routes")
-                
-                # Cache the result
-                self.cache[code_hash] = clean_code
-                flow.response.text = clean_code
-                flow.response.headers["X-Lazarus-Processed"] = "TRUE"
-                flow.response.headers["X-Lazarus-Routes"] = str(len(routes)) if 'routes' in dir() and routes else "0"
-                
-                logger.info(f"[Lazarus] De-obfuscated {code_hash[:8]} ({len(original_code)} -> {len(clean_code)} chars)")
-                
-            finally:
-                # Remove from processing set
-                self._processing.discard(code_hash)
-                
+
         except Exception as e:
-            logger.error(f"[Lazarus] Failed to process: {e}")
+            logger.error(f"[Lazarus] Passive analysis failed: {e}")
     
     def _extract_api_routes(self, code: str) -> list:
         """

--- a/core/ghost/proxy.py
+++ b/core/ghost/proxy.py
@@ -19,6 +19,7 @@ Intersects live traffic and feeds Cortex with real-time attack surface data.
 
 import asyncio
 import logging
+import os
 import threading
 from typing import Optional
 
@@ -28,6 +29,13 @@ from core.base.session import ScanSession
 from core.ai.strategy import StrategyEngine
 
 logger = logging.getLogger(__name__)
+
+# Preferred, STABLE proxy port. The capture browser pins --proxy-server at
+# launch, so a random port per Start would orphan the browser on every
+# restart (and historically left zombie listeners behind). A fixed port keeps
+# capture windows valid across restarts. Falls back to an ephemeral port only
+# if this one is taken. Override with SENTINEL_GHOST_PORT.
+DEFAULT_GHOST_PORT = int(os.getenv("SENTINEL_GHOST_PORT", "8787"))
 
 class GhostAddon:
     """
@@ -62,7 +70,21 @@ class GhostAddon:
         # Intercept auth headers and cookies for Wraith tools
         from core.wraith.session_bridge import SessionBridge
         self.session_bridge = SessionBridge(session)
-        
+
+        # [DECONFLICTION HEADER]
+        # HackerOne's policy (and most programs) require an identifying header
+        # on ALL test traffic so the program can attribute it to you. We stamp
+        # every OUTBOUND request with it. Disabled unless a value is set.
+        #   SENTINEL_GHOST_BB_HEADER  -> header name  (default "X-Bug-Bounty")
+        #   SENTINEL_GHOST_BB_VALUE   -> header value (e.g. your H1 handle)
+        self._bb_header = os.getenv("SENTINEL_GHOST_BB_HEADER", "X-Bug-Bounty").strip()
+        self._bb_value = os.getenv("SENTINEL_GHOST_BB_VALUE", "").strip()
+        if self._bb_value:
+            logger.info(
+                "[Ghost] deconfliction header enabled: %s: %s",
+                self._bb_header, self._bb_value,
+            )
+
         logger.info("[Ghost] CAL integration enabled - traffic will emit Evidence")
 
     def request(self, flow: http.HTTPFlow):
@@ -71,16 +93,31 @@ class GhostAddon:
         Emits CAL Evidence for every request.
         Phase 4-G2: also feeds the FlowMapper for any active recordings.
         """
+        # ── Read the essentials up front (cheap; must not fail) ──────────
         try:
             url = flow.request.pretty_url
             method = flow.request.method
             host = flow.request.host
+        except Exception as e:
+            logger.error(f"[Ghost] request: unreadable flow, skipping: {e}")
+            return
 
-            # ═══════════════════════════════════════════════════════════════
-            # SCOPE ENFORCEMENT GUARD
-            # ═══════════════════════════════════════════════════════════════
-            scope_context = getattr(self.session, "scope_context", None)
-            if scope_context:
+        # ── Deconfliction header (bug-bounty attribution) ────────────────
+        # Stamp every outbound request so the program can identify our test
+        # traffic. Unlike response handling, modifying the OUTBOUND request is
+        # intended here — it's the whole point of the deconfliction marker.
+        if self._bb_value:
+            try:
+                flow.request.headers[self._bb_header] = self._bb_value
+            except Exception:
+                pass
+
+        # ═══════════════════════════════════════════════════════════════
+        # SCOPE ENFORCEMENT GUARD (security — runs before anything else)
+        # ═══════════════════════════════════════════════════════════════
+        scope_context = getattr(self.session, "scope_context", None)
+        if scope_context:
+            try:
                 from core.base.scope import ScopeDecision
                 decision = scope_context.registry.resolve(url)
                 is_bounty = scope_context.mode.upper() == "BOUNTY"
@@ -89,39 +126,27 @@ class GhostAddon:
                     from mitmproxy.http import Response
                     flow.response = Response.make(403, b"Blocked by SentinelForge ScopeGuard")
                     return
+            except Exception as e:
+                logger.error(f"[Ghost] scope check error: {e}")
 
-            # 1. Log the 'Sight'
-            msg = f"[Ghost] Intercepted: {method} {url}"
-            self.session.log(msg)
-
-            # [MIMIC INTEGRATION]
-            # Mine the Route
-            self.shadow_spec.observe(method, url)
-
-            # [SESSION BRIDGE]
-            # Capture outbound authentication tokens/cookies
-            self.session_bridge.observe_request(flow)
-
-            # ═══════════════════════════════════════════════════════════════
-            # PHASE 4-G2: Feed the FlowMapper for any active recordings.
-            # ═══════════════════════════════════════════════════════════════
-            # The addon observes every request. Each active recording flow
-            # gets a step recorded. We stash the per-flow step_ids on the
-            # mitmproxy flow's metadata so the response hook can finalize
-            # the SAME steps when the response lands.
+        # ═══════════════════════════════════════════════════════════════
+        # CAPTURE FIRST — record the step BEFORE any analysis.
+        # ═══════════════════════════════════════════════════════════════
+        # Recording is the core job of a passive proxy and must never be
+        # sacrificed to a downstream analysis failure (a CAL event-contract
+        # violation, a strategy/shadow-spec error, etc.). So it runs in its
+        # own isolated try, AHEAD of shadow-spec / session-bridge / CAL /
+        # strategy. Previously these ran first, and a single contract
+        # violation aborted the whole hook — recording nothing.
+        try:
             from core.ghost.flow import FlowMapper, MAX_BODY_BYTES
             fm = FlowMapper.instance()
             req_content_type = flow.request.headers.get("content-type", "") or None
-            # Capture request body, capped at MAX_BODY_BYTES to keep flow
-            # files reasonably sized. We always decode UTF-8 with replace
-            # so binary uploads don't blow up json.dump downstream.
             raw_body = flow.request.content or b""
             truncated = len(raw_body) > MAX_BODY_BYTES
             if truncated:
                 raw_body = raw_body[:MAX_BODY_BYTES]
             req_body_str = raw_body.decode("utf-8", errors="replace")
-            # Params: union of query and form-data (best-effort — mitmproxy
-            # parses these for us).
             params: dict = {}
             try:
                 params.update(dict(flow.request.query) if flow.request.query else {})
@@ -141,24 +166,25 @@ class GhostAddon:
                 request_body_truncated=truncated,
                 request_content_type=req_content_type,
             )
-            # Stash on the mitmproxy flow object so response() can find
-            # them. mitmproxy lets us attach arbitrary attributes to
-            # flow.metadata (a dict).
             if step_ids:
-                flow.metadata["sentinel_step_ids"] = step_ids
-                # Record the request-start time for elapsed_ms math in
-                # response().
                 import time as _t
+                flow.metadata["sentinel_step_ids"] = step_ids
                 flow.metadata["sentinel_request_start"] = _t.time()
-            
-            # ═══════════════════════════════════════════════════════════════
-            # CAL INTEGRATION: Emit Evidence for this request
-            # ═══════════════════════════════════════════════════════════════
-            # Every HTTP request is a data point that can support/dispute claims.
-            # For example:
-            #   - If strategy claimed "user_id param exists", this evidence proves it
-            #   - If we see auth headers, we have evidence of authentication scheme
-            #
+        except Exception as e:
+            logger.error(f"[Ghost] step recording failed: {e}")
+
+        # ═══════════════════════════════════════════════════════════════
+        # ANALYSIS (best-effort) — MUST NOT be able to abort capture above.
+        # ═══════════════════════════════════════════════════════════════
+        try:
+            self.session.log(f"[Ghost] Intercepted: {method} {url}")
+
+            # [MIMIC] mine the route
+            self.shadow_spec.observe(method, url)
+            # [SESSION BRIDGE] capture outbound auth tokens/cookies
+            self.session_bridge.observe_request(flow)
+
+            # CAL: emit Evidence for this request (traffic is fact)
             query = flow.request.query
             from core.cal.types import Evidence, Provenance
             traffic_evidence = Evidence(
@@ -174,18 +200,14 @@ class GhostAddon:
                 provenance=Provenance(
                     source="Ghost:request",
                     method="traffic_interception",
-                    run_id=self.session.session_id
+                    run_id=self.session.session_id,
                 ),
-                confidence=1.0  # Traffic is fact
+                confidence=1.0,
             )
-            
-            # Add to the global reasoning session
             self.reasoning_engine.reasoning_session.evidence[traffic_evidence.id] = traffic_evidence
-            logger.debug(f"[CAL] Ghost emitted request Evidence: {traffic_evidence.id}")
-            
-            # 2. Analyze Attack Surface (Quick Heuristics)
+
+            # Attack-surface heuristics for parameterized endpoints
             if query:
-                # "Passive Node" discovery
                 self.session.findings.add_finding({
                     "tool": "ghost_proxy",
                     "type": "endpoint_discovery",
@@ -195,22 +217,23 @@ class GhostAddon:
                         "url": url,
                         "params": list(query.keys()),
                         "method": method,
-                        "cal_evidence_id": traffic_evidence.id  # Link to CAL
+                        "cal_evidence_id": traffic_evidence.id,
                     }
                 })
-
-                # 3. TRIGGER NEURAL STRATEGY (The God Tier Logic)
-                if self.session.ghost and self.session.ghost._task:
-                     flow_data = {
-                         "url": url,
-                         "method": method,
-                         "host": host,
-                         "params": list(query.keys())
-                     }
-                     asyncio.create_task(self.strategy.propose_attacks(flow_data))
-                
+                # NOTE: We deliberately do NOT spawn per-request LLM strategy
+                # analysis here. Doing so (asyncio.create_task(strategy.
+                # propose_attacks)) ran an AI call *inside mitmproxy's event
+                # loop on every parameterized request*, hit an un-awaited
+                # coroutine bug ("object of type 'coroutine' has no len()"),
+                # raised "Unhandled error in task", and caused upstream
+                # disconnects — which broke the very page being browsed
+                # (renders + scrolls, but click handlers never attach).
+                # A passive capture proxy must stay lean. Mutation/strategy
+                # analysis runs OFFLINE on the recorded flow via the
+                # "Propose Mutations" action — no per-request LLM in the
+                # interception path.
         except Exception as e:
-            logger.error(f"[Ghost] Request processing error: {e}")
+            logger.error(f"[Ghost] Request analysis error (capture unaffected): {e}")
 
     async def response(self, flow: http.HTTPFlow):
         """
@@ -269,10 +292,10 @@ class GhostAddon:
                         elapsed_ms=elapsed_ms,
                     )
 
-            # Lazarus Engine: De-obfuscation (async)
-            # We await this so the response is held until the AI is done rewriting it
+            # Lazarus Engine: PASSIVE route analysis only (read-only).
+            # The response body is NEVER modified — Ghost is a passive proxy.
+            # This is fast static extraction, not an LLM rewrite.
             if self.lazarus.should_process(flow):
-                self.session.log(f"[Lazarus] De-obfuscating JS: {flow.request.pretty_url}")
                 await self._process_lazarus(flow)
 
         except Exception as e:
@@ -326,20 +349,49 @@ class GhostInterceptor:
 
     @staticmethod
     def _find_free_port() -> int:
-        """Find an available port for the proxy."""
+        """Find a port for the proxy, preferring the STABLE default.
+
+        Tries DEFAULT_GHOST_PORT first so capture-browser windows (which pin
+        --proxy-server at launch) stay valid across proxy restarts. Falls back
+        to an ephemeral free port only if the stable one is already in use.
+        """
         import socket
-        # Context-managed operation.
+        # Try the stable preferred port.
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            probe.bind(('127.0.0.1', DEFAULT_GHOST_PORT))
+            return DEFAULT_GHOST_PORT
+        except OSError:
+            logger.info(
+                "[Ghost] preferred port %d busy; using an ephemeral port",
+                DEFAULT_GHOST_PORT,
+            )
+        finally:
+            probe.close()
+        # Ephemeral fallback.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(('127.0.0.1', 0))
             s.listen(1)
-            port = s.getsockname()[1]
-        return port
+            return s.getsockname()[1]
 
     async def start(self):
         """
         Starts the proxy as an asyncio task.
         """
         opts = options.Options(listen_host='127.0.0.1', listen_port=self.port)
+
+        # Force HTTP/1.1 for interception. mitmproxy's HTTP/2 handling here
+        # throws "RECV_PING in state CLOSED" and disconnects upstream
+        # connections; when a site's scripts ride those dropped H2 streams
+        # they fail to load and the page renders but its click handlers never
+        # attach (scroll works, clicks don't). HTTP/1.1 is slower but far more
+        # reliable for capture, and is what Burp/ZAP recommend for stability.
+        for _opt in ("http2", "http2_priority"):
+            try:
+                setattr(opts, _opt, False)
+            except Exception:
+                pass
+
         self.master = DumpMaster(opts, with_termlog=False, with_dumper=False)
         self.master.addons.add(GhostAddon(self.session))
         
@@ -362,13 +414,59 @@ class GhostInterceptor:
              # Catch Any other hard crash (KeyboardInterrupt etc)
              logger.warning(f"[Ghost] Proxy hard stop: {e}")
 
-    def stop(self):
-        """Shutdown the proxy gracefully."""
-        # Conditional branch.
+    async def stop(self):
+        """Shut the proxy down and RELEASE THE PORT.
+
+        BUG THIS FIXES: the previous version called master.shutdown() and then
+        IMMEDIATELY task.cancel(), cancelling the run task before mitmproxy
+        finished closing its listening socket. That leaked the port — every
+        Start/Stop left a zombie listener that still accepted connections but
+        reset every upstream TLS handshake (SSL_ERROR_SYSCALL). A capture
+        browser pointed at a zombie would load nothing / render a dead page.
+
+        FIX: explicitly close the proxyserver's listener (in mitmproxy 12 the
+        socket is owned by the proxyserver addon's Servers and is NOT freed
+        just by master.shutdown()/run() returning — verified: the port stayed
+        bound across stop cycles). We reconfigure to ZERO servers, which closes
+        the socket, THEN signal shutdown and await the run task.
+        """
+        # 1. Close the listener socket(s) — frees the port. mitmproxy 12.
         if self.master:
-            self.master.shutdown()
-        # Conditional branch.
-        if self._task and not self._task.done():
-            self._task.cancel()
-        logger.info("[*] Ghost Protocol Deactivated.")
+            try:
+                ps = self.master.addons.get("proxyserver")
+                if ps is not None and getattr(ps, "servers", None) is not None:
+                    await ps.servers.update([])
+            except Exception as e:
+                logger.warning(f"[Ghost] proxyserver close error: {e}")
+
+        # 2. Signal the master to exit.
+        if self.master:
+            try:
+                self.master.shutdown()
+            except Exception as e:
+                logger.warning(f"[Ghost] master.shutdown() error: {e}")
+
+        task = self._task
+        if task is not None and not task.done():
+            try:
+                # Let the master close its listener cleanly. Do NOT cancel
+                # first — cancelling mid-shutdown is exactly what leaked the
+                # socket. shield() so our wait_for timeout doesn't cancel the
+                # underlying task prematurely.
+                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("[Ghost] master did not exit in 5s; force-cancelling")
+                task.cancel()
+                try:
+                    await task
+                except BaseException:
+                    pass
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.warning(f"[Ghost] stop wait error: {e}")
+
+        self._task = None
+        self.master = None
+        logger.info("[*] Ghost Protocol Deactivated (port released).")
 

--- a/core/server/routers/ghost.py
+++ b/core/server/routers/ghost.py
@@ -237,16 +237,11 @@ async def stop_ghost(_: bool = Depends(verify_sensitive_token)) -> GhostStopResp
         )
 
     try:
-        _INTERCEPTOR.stop()
-        # Give the asyncio task a moment to actually finish cancellation
-        # so subsequent /start calls don't trip over a half-dead master.
-        task = getattr(_INTERCEPTOR, "_task", None)
-        if task is not None:
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                # Don't care — shutdown is best-effort.
-                pass
+        # stop() is now async and graceful: it signals shutdown and waits for
+        # the run task to finish so the listener socket is fully closed and the
+        # port released before we drop the reference. (Previously stop() cancelled
+        # the task mid-shutdown, leaking a zombie listener on the port.)
+        await _INTERCEPTOR.stop()
     except Exception as e:
         logger.warning(f"[Ghost] stop encountered: {type(e).__name__}: {e}")
 

--- a/tests/integration/test_ghost_lazarus_integration.py
+++ b/tests/integration/test_ghost_lazarus_integration.py
@@ -1,16 +1,19 @@
 """
 Integration Test: Ghost/Lazarus Pipeline
 
-CRITICAL INVARIANT:
-GhostAddon.response() must correctly invoke LazarusEngine.response() for eligible
-JavaScript responses without crashing or blocking the HTTP flow.
+CRITICAL INVARIANTS:
+1. GhostAddon.response() (an ASYNC mitmproxy hook) invokes LazarusEngine for
+   eligible JavaScript responses and survives Lazarus failures.
+2. Lazarus is PASSIVE: it must never modify flow.response — the browser
+   receives the server's bytes unchanged (test_lazarus_never_mutates_response_body).
 
-This test was written to verify the fix for TODO #2:
-"GhostAddon.response() calls self.lazarus.process(flow) but LazarusEngine has
-no process method - only has response() and _process_async() methods"
-
-The fix uses asyncio.create_task() to invoke LazarusEngine.response() asynchronously,
-allowing the HTTP response to continue without blocking.
+History: these tests were originally written assuming response() was a
+*synchronous* hook that scheduled work via asyncio.create_task(). The code is
+actually `async def response()`, which mitmproxy awaits — so the old tests
+called it unawaited, the body never ran, and the suite silently exercised
+nothing. That gap is why a regression (Lazarus overwriting JS response bodies
+with a truncated LLM rewrite) shipped undetected. The tests now await the hook
+and assert byte-transparency.
 """
 
 import asyncio
@@ -50,6 +53,10 @@ def _create_mock_js_flow() -> http.HTTPFlow:
     flow.response.content = obfuscated_js.encode()
     flow.response.text = obfuscated_js
 
+    # Real dict so the response() FlowMapper-finalize branch sees no step_ids
+    # (a bare Mock would be truthy and crash the iteration).
+    flow.metadata = {}
+
     return flow
 
 
@@ -64,6 +71,7 @@ def _create_mock_non_js_flow() -> http.HTTPFlow:
     flow.response.headers = {"content-type": "text/html"}
     flow.response.content = b"<html><body>Hello</body></html>"
     flow.response.text = "<html><body>Hello</body></html>"
+    flow.metadata = {}
 
     return flow
 
@@ -86,6 +94,10 @@ async def test_ghost_lazarus_integration_success():
     # Create GhostAddon (this internally creates LazarusEngine)
     addon = GhostAddon(session)
 
+    # SessionBridge expects a real mitmproxy Headers object (.get_all); the
+    # mock flow uses a plain dict, so neutralize it — it's not under test here.
+    addon.session_bridge = Mock()
+
     # Mock LazarusEngine.response() to track if it's called
     original_response = addon.lazarus.response
     addon.lazarus.response = AsyncMock(side_effect=original_response)
@@ -93,11 +105,9 @@ async def test_ghost_lazarus_integration_success():
     # Create JavaScript flow
     js_flow = _create_mock_js_flow()
 
-    # Execute: Call response() (this is synchronous, schedules async work)
-    addon.response(js_flow)
-
-    # Give asyncio time to schedule and execute the task
-    await asyncio.sleep(0.1)
+    # Execute: response() is an async mitmproxy hook — await it directly.
+    # (It used to be invoked unawaited, so this body never actually ran.)
+    await addon.response(js_flow)
 
     # Verify: LazarusEngine.response() was called
     addon.lazarus.response.assert_called_once()
@@ -123,6 +133,7 @@ async def test_ghost_lazarus_integration_non_js_skipped():
     session.findings.add_finding = Mock()
 
     addon = GhostAddon(session)
+    addon.session_bridge = Mock()
 
     # Mock LazarusEngine.response() to track calls
     addon.lazarus.response = AsyncMock()
@@ -130,9 +141,8 @@ async def test_ghost_lazarus_integration_non_js_skipped():
     # Create HTML flow (not JavaScript)
     html_flow = _create_mock_non_js_flow()
 
-    # Execute
-    addon.response(html_flow)
-    await asyncio.sleep(0.1)
+    # Execute (async hook — await it)
+    await addon.response(html_flow)
 
     # Verify: LazarusEngine.response() was NOT called
     addon.lazarus.response.assert_not_called()
@@ -150,6 +160,7 @@ async def test_ghost_lazarus_error_handling():
     session.findings.add_finding = Mock()
 
     addon = GhostAddon(session)
+    addon.session_bridge = Mock()
 
     # Mock LazarusEngine.response() to raise an error
     addon.lazarus.response = AsyncMock(side_effect=Exception("AI service unavailable"))
@@ -157,9 +168,8 @@ async def test_ghost_lazarus_error_handling():
     # Create JavaScript flow
     js_flow = _create_mock_js_flow()
 
-    # Execute: Should not crash despite Lazarus error
-    addon.response(js_flow)
-    await asyncio.sleep(0.1)
+    # Execute: Should not crash despite Lazarus error (async hook — await it)
+    await addon.response(js_flow)
 
     # Verify: Error was captured as a finding
     error_findings = [
@@ -209,31 +219,76 @@ async def test_lazarus_should_process_filtering():
     assert lazarus.should_process(large_js_flow) is False
 
 
-def test_ghost_addon_synchronous_response_hook():
+@pytest.mark.asyncio
+async def test_ghost_addon_response_hook_is_awaitable():
     """
-    INVARIANT: GhostAddon.response() must be synchronous (not async).
+    INVARIANT: GhostAddon.response() is an ASYNC mitmproxy hook.
 
-    This is required by mitmproxy's addon interface - the response() hook is sync.
-    We use asyncio.create_task() internally to schedule async work.
+    mitmproxy awaits coroutine addon hooks, so response() is async (unlike
+    request(), which is sync). This test previously asserted the hook was
+    *synchronous* — which never matched the code, so it failed and emitted
+    'coroutine was never awaited' warnings, and the real response path was
+    never exercised by the suite (which is how the JS-rewrite bug slipped in).
     """
     session = ScanSession(target="example.com")
     session.findings = Mock(spec=FindingsStore)
     session.findings.add_finding = Mock()
 
     addon = GhostAddon(session)
-
-    # Mock to prevent actual processing
+    addon.session_bridge = Mock()
     addon.lazarus.should_process = Mock(return_value=False)
 
-    # Create flow
     flow = _create_mock_non_js_flow()
 
-    # Execute: This must complete synchronously (not return a coroutine)
-    result = addon.response(flow)
+    coro = addon.response(flow)
+    assert asyncio.iscoroutine(coro)
+    result = await coro
+    assert result is None
 
-    # Verify: response() returns None (not a coroutine)
-    assert result is None  # Sync functions return None, not awaitable
-    assert not asyncio.iscoroutine(result)
+
+@pytest.mark.asyncio
+async def test_lazarus_never_mutates_response_body():
+    """
+    CRITICAL REGRESSION INVARIANT: Ghost is a PASSIVE proxy — Lazarus must
+    never modify the response body the browser receives.
+
+    A prior version overwrote flow.response.text with a truncated, LLM
+    "de-obfuscated" rewrite (and, due to an async bug, the string repr of an
+    un-awaited coroutine). That corrupted every in-bounds script: pages
+    rendered and scrolled, but all click handlers were dead. This locks in
+    byte-transparency so that regression can never return silently.
+    """
+    lazarus = LazarusEngine.instance()
+
+    # Real JS containing an API route the passive miner should still find.
+    js = (
+        ("function handler(e){e.preventDefault()}\n" * 30)
+        + 'fetch("/api/v1/orders");\n'
+        + ("var counter = 0;\n" * 30)
+    )
+    flow = Mock(spec=http.HTTPFlow)
+    flow.request = Mock()
+    flow.request.pretty_url = "https://example.com/bundle.js"
+    flow.response = Mock()
+    flow.response.headers = {"content-type": "application/javascript"}
+    flow.response.content = js.encode()
+    flow.response.text = js
+
+    before = flow.response.text
+
+    # Patch the event bus so route-finding emission doesn't require the global
+    # sequence authority; we only care that the BODY is left untouched.
+    with patch("core.cortex.events.get_event_bus", return_value=Mock()):
+        await lazarus._process_async(flow)
+
+    # The body must be byte-identical after Lazarus runs.
+    assert flow.response.text == before
+    assert "coroutine object" not in flow.response.text
+    assert "[Lazarus] De-obfuscated" not in flow.response.text
+
+    # Passive-analysis VALUE is preserved: the route is still mined statically.
+    routes = lazarus._extract_api_routes(js)
+    assert any(r["path"] == "/api/v1/orders" for r in routes)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_ghost_proxy_lifecycle.py
+++ b/tests/integration/test_ghost_proxy_lifecycle.py
@@ -1,0 +1,93 @@
+"""
+Integration test: Ghost proxy lifecycle — the port MUST be released on stop.
+
+REGRESSION GUARD for the zombie-listener bug:
+    GhostInterceptor.stop() used to call master.shutdown() then immediately
+    task.cancel(), cancelling the run task before mitmproxy finished closing
+    its listening socket. In mitmproxy 12 the socket is owned by the
+    proxyserver addon and is NOT freed just by the master exiting — so every
+    Start/Stop leaked a listener that still accepted connections but RESET
+    every upstream TLS handshake (SSL_ERROR_SYSCALL). A capture browser
+    pointed at such a zombie loaded nothing / rendered a dead page.
+
+These tests assert that after stop():
+    1. the port is RELEASED (no leaked listener), and
+    2. the SAME port can be re-bound immediately (proving a clean release,
+       which is also what lets the stable-port capture browser keep working
+       across restarts).
+"""
+
+import asyncio
+import socket
+
+import pytest
+from unittest.mock import MagicMock
+
+# A high port unlikely to collide on a dev box or CI runner. We drive the
+# interceptor on an EXPLICIT port so the "re-bind same port" assertion is
+# deterministic regardless of the stable-default-port availability.
+TEST_PORT = 8799
+
+
+def _is_listening(port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.5)
+    try:
+        return s.connect_ex(("127.0.0.1", port)) == 0
+    finally:
+        s.close()
+
+
+@pytest.mark.asyncio
+async def test_ghost_proxy_releases_port_on_stop(monkeypatch):
+    """A start/stop cycle must leave the port free and immediately re-usable."""
+    from core.ghost import proxy as gp
+
+    # Isolate the interceptor's listener lifecycle from the heavyweight
+    # GhostAddon (which pulls in Lazarus / ShadowSpec / reasoning engine).
+    # We only care about the proxy server's socket here.
+    monkeypatch.setattr(gp, "GhostAddon", lambda session: type("NoopAddon", (), {})())
+
+    session = MagicMock()
+
+    # --- Cycle 1 ---
+    interceptor = gp.GhostInterceptor(session, port=TEST_PORT)
+    await interceptor.start()
+    await asyncio.sleep(0.8)  # let mitmproxy bind the listener
+    assert _is_listening(TEST_PORT), "proxy should be listening after start()"
+
+    await interceptor.stop()
+    await asyncio.sleep(0.5)
+    assert not _is_listening(TEST_PORT), (
+        f"port {TEST_PORT} MUST be released after stop() — a leaked listener "
+        "is the zombie-proxy bug that reset all TLS and broke captured pages"
+    )
+
+    # --- Cycle 2 on the SAME port: only possible if cycle 1 truly released it ---
+    interceptor2 = gp.GhostInterceptor(session, port=TEST_PORT)
+    await interceptor2.start()
+    await asyncio.sleep(0.8)
+    assert _is_listening(TEST_PORT), (
+        "second start() on the same port failed — the port was not cleanly "
+        "released by the first stop()"
+    )
+    await interceptor2.stop()
+    await asyncio.sleep(0.5)
+    assert not _is_listening(TEST_PORT), "port must be released after the second stop() too"
+
+
+@pytest.mark.asyncio
+async def test_find_free_port_prefers_stable_default(monkeypatch):
+    """_find_free_port() prefers the stable default when it's free.
+
+    The stable port is what lets a capture-browser window (which pins
+    --proxy-server at launch) survive proxy restarts instead of being
+    orphaned on a fresh random port each time.
+    """
+    from core.ghost import proxy as gp
+
+    # Only meaningful if the default port happens to be free on this machine.
+    if _is_listening(gp.DEFAULT_GHOST_PORT):
+        pytest.skip(f"default port {gp.DEFAULT_GHOST_PORT} busy on this host")
+
+    assert gp.GhostInterceptor._find_free_port() == gp.DEFAULT_GHOST_PORT

--- a/ui/SentinelForge.xcodeproj/project.pbxproj
+++ b/ui/SentinelForge.xcodeproj/project.pbxproj
@@ -10,9 +10,9 @@
 		0D5D3E555E784A70305E042C /* HelixAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58466552B0906B21951240F1 /* HelixAppState.swift */; };
 		120436A0BDDDBF24C31F8D30 /* MainWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28396B11B909875C4B8BB20 /* MainWindowView.swift */; };
 		14F802FA073267C118AFB865 /* SentinelAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B35BB2EF550D1169E8CFED /* SentinelAPIClient.swift */; };
+		15CD472F66509C7A4B858EA9 /* VerifyConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9621E8CBC929F4AEEBBC33A /* VerifyConsoleView.swift */; };
 		1A516CAE139B1C4AE47F16B6 /* BackendState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AEE541E4462F9FE3D09CB8 /* BackendState.swift */; };
 		1B98978EE51F29E8B509AA59 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E654B5888ACF358B53174849 /* ReportView.swift */; };
-		75594BCD91644EB9B9031061 /* BountyReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72507FD37EBD46AC963C6E14 /* BountyReportView.swift */; };
 		23885C7C1426DA781B5E460F /* NeuralGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DA56ED4F2F3426B9E02034 /* NeuralGraphView.swift */; };
 		250D8E25220B3AB535717493 /* ChatBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBD4BFB76B48DD1736FC1FA /* ChatBubbleView.swift */; };
 		2F3DA20D5D2C21A0200A21C9 /* SharedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D47C9AABA588CA41003B700 /* SharedModels.swift */; };
@@ -28,10 +28,13 @@
 		6ACAA9191D686B0F50DE6548 /* OperationalStateModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882050DB17B4CE0CB0263245 /* OperationalStateModels.swift */; };
 		74987EE4B7580B65E63446E7 /* TerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62409FA58DFFE1F4DBADB601 /* TerminalView.swift */; };
 		80A6BB3BC05E24DFF75831EB /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = B8394185D36FC0D1095C1111 /* Shaders.metal */; };
+		8226DC9F780680AC29BC0FDB /* GhostAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E92E19E923FA9F4CEDD71B /* GhostAPIClient.swift */; };
 		84565490131B06C520A4801A /* LLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E8FDC8C9DD1772F9943B8F /* LLMService.swift */; };
 		854DB144D784ECD29694882E /* StatusComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2569FD3CDF297078C1886472 /* StatusComponents.swift */; };
 		8F1F1CC3866F00EBB302665E /* TierBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B9FBAAB3F224DEE97A35DE /* TierBadgeView.swift */; };
+		8FAA39F14BE46EA50154291A /* FoundryConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBADD02037E358509CA4563 /* FoundryConsoleView.swift */; };
 		9369DFE67CE6BB7E573BBAB3 /* AuditFeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68494FDEACABC92B894B50 /* AuditFeedView.swift */; };
+		94A8F26426D3FD86CFDC31BD /* VerifyAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E914AE1A9757AE1CCF0849 /* VerifyAPIClient.swift */; };
 		96387A0346121E0ACC566A88 /* PressureGraphModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A57E58ABCFE5304C0257CA6 /* PressureGraphModels.swift */; };
 		9AD2014C3C59940C44A7233D /* NetworkGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E61DA673B2F360C4460F9F9 /* NetworkGraphView.swift */; };
 		9E5726936E260B4FCC10DF3F /* PTYClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C910B6EF70385F75EC7BA /* PTYClient.swift */; };
@@ -51,8 +54,12 @@
 		C4EAE38493520E1B56033FEE /* GraphModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493C6711EF03532E783C01F1 /* GraphModels.swift */; };
 		C4EDBDE9C6812EFA33977B44 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1269D7C35447A70FD8D1D9FB /* ChatView.swift */; };
 		C94EFAA35A0D3B712FC57FB6 /* GenerateModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2629EBACF27C2661DD8B72E7 /* GenerateModels.swift */; };
+		C97C66E3ACF3313E004CBE13 /* GhostCaptureBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E965EAA183C95650BC9FC8 /* GhostCaptureBrowser.swift */; };
+		D0C5750A70133A74C61FED34 /* FoundryAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC166B404EED51D85979004C /* FoundryAPIClient.swift */; };
+		DBAB5790AC80CE69F7F453E4 /* BountyReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59070AC06A493619616984F /* BountyReportView.swift */; };
 		E75B45E5BB77A4B604D97732 /* ScanControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1614A34830DE729E55890F6 /* ScanControlView.swift */; };
 		F1D02E19B9E5B252F227CA09 /* GraphRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19E9F4E50E60ADC4DBDE5B7 /* GraphRenderer.swift */; };
+		FAF5F3644A98AEA223E96513 /* GhostConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9D7718A76376AF130F1182 /* GhostConsoleView.swift */; };
 		FB54B31E033C572BFA666FB3 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4C5DC1C91D1C3867752C8 /* AnyCodable.swift */; };
 		FD713260357E395BCDCB0682 /* BackendManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7308F0EA7AC9B332BAD2C77B /* BackendManager.swift */; };
 /* End PBXBuildFile section */
@@ -68,6 +75,7 @@
 		24341BFC06FC18EE38977FFC /* SentinelForge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SentinelForge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2569FD3CDF297078C1886472 /* StatusComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusComponents.swift; sourceTree = "<group>"; };
 		2629EBACF27C2661DD8B72E7 /* GenerateModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateModels.swift; sourceTree = "<group>"; };
+		2DBADD02037E358509CA4563 /* FoundryConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundryConsoleView.swift; sourceTree = "<group>"; };
 		3A57E58ABCFE5304C0257CA6 /* PressureGraphModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressureGraphModels.swift; sourceTree = "<group>"; };
 		3E61DA673B2F360C4460F9F9 /* NetworkGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkGraphView.swift; sourceTree = "<group>"; };
 		426219598E6076D786D8DAD8 /* ReportComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportComposerView.swift; sourceTree = "<group>"; };
@@ -86,12 +94,15 @@
 		7E340539956225F2B0A21565 /* ErrorClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorClassifier.swift; sourceTree = "<group>"; };
 		81B35BB2EF550D1169E8CFED /* SentinelAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelAPIClient.swift; sourceTree = "<group>"; };
 		8318D0791A1940E626D7A7ED /* ModelRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRouter.swift; sourceTree = "<group>"; };
+		86E92E19E923FA9F4CEDD71B /* GhostAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostAPIClient.swift; sourceTree = "<group>"; };
 		882050DB17B4CE0CB0263245 /* OperationalStateModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalStateModels.swift; sourceTree = "<group>"; };
+		8E9D7718A76376AF130F1182 /* GhostConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostConsoleView.swift; sourceTree = "<group>"; };
 		8FD7FEF00ADB9A4983F8F7F4 /* DecisionStreamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecisionStreamView.swift; sourceTree = "<group>"; };
 		946E142FF6202E3202EA5B2D /* RetryBackoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryBackoff.swift; sourceTree = "<group>"; };
 		9BB1DE1E3EE6C98ABFF1F47D /* BackendSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendSettingsView.swift; sourceTree = "<group>"; };
 		A0AEE541E4462F9FE3D09CB8 /* BackendState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendState.swift; sourceTree = "<group>"; };
 		A19E9F4E50E60ADC4DBDE5B7 /* GraphRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphRenderer.swift; sourceTree = "<group>"; };
+		A6E965EAA183C95650BC9FC8 /* GhostCaptureBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostCaptureBrowser.swift; sourceTree = "<group>"; };
 		AA7A4E2BDBAF9FC290B68C79 /* EventStreamClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStreamClient.swift; sourceTree = "<group>"; };
 		B1614A34830DE729E55890F6 /* ScanControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanControlView.swift; sourceTree = "<group>"; };
 		B28396B11B909875C4B8BB20 /* MainWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowView.swift; sourceTree = "<group>"; };
@@ -100,13 +111,16 @@
 		BB064037D50A118943B7AB93 /* ActionRequestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRequestView.swift; sourceTree = "<group>"; };
 		BCE68CC8F07C4B289363C486 /* CortexStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CortexStream.swift; sourceTree = "<group>"; };
 		C303CDE894C92523DAC01B0A /* ToolsBankView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsBankView.swift; sourceTree = "<group>"; };
+		C9621E8CBC929F4AEEBBC33A /* VerifyConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyConsoleView.swift; sourceTree = "<group>"; };
 		CA1FB66EC2747EC1973D336E /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
 		CDA17BE4D58A8FE361029BE7 /* ToolMetadataModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolMetadataModels.swift; sourceTree = "<group>"; };
 		D45E68340782F5F007892DD6 /* HelixError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelixError.swift; sourceTree = "<group>"; };
 		D6ADAB1DD2D246A739B3EC7E /* PressureShader.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = PressureShader.metal; sourceTree = "<group>"; };
+		DC166B404EED51D85979004C /* FoundryAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundryAPIClient.swift; sourceTree = "<group>"; };
 		E654B5888ACF358B53174849 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
-		72507FD37EBD46AC963C6E14 /* BountyReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BountyReportView.swift; sourceTree = "<group>"; };
 		F2E8FDC8C9DD1772F9943B8F /* LLMService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMService.swift; sourceTree = "<group>"; };
+		F59070AC06A493619616984F /* BountyReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BountyReportView.swift; sourceTree = "<group>"; };
+		F6E914AE1A9757AE1CCF0849 /* VerifyAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyAPIClient.swift; sourceTree = "<group>"; };
 		FEBD4BFB76B48DD1736FC1FA /* ChatBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBubbleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -132,6 +146,14 @@
 				CDA17BE4D58A8FE361029BE7 /* ToolMetadataModels.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		2B95CA1995A2BE267BF78942 /* Verify */ = {
+			isa = PBXGroup;
+			children = (
+				C9621E8CBC929F4AEEBBC33A /* VerifyConsoleView.swift */,
+			);
+			path = Verify;
 			sourceTree = "<group>";
 		};
 		2BE62123C101D1A0E78E9AC3 = {
@@ -160,14 +182,26 @@
 				7308F0EA7AC9B332BAD2C77B /* BackendManager.swift */,
 				BCE68CC8F07C4B289363C486 /* CortexStream.swift */,
 				AA7A4E2BDBAF9FC290B68C79 /* EventStreamClient.swift */,
+				DC166B404EED51D85979004C /* FoundryAPIClient.swift */,
 				2629EBACF27C2661DD8B72E7 /* GenerateModels.swift */,
+				86E92E19E923FA9F4CEDD71B /* GhostAPIClient.swift */,
+				A6E965EAA183C95650BC9FC8 /* GhostCaptureBrowser.swift */,
 				008A72B75EBAE4A0EB5BB1FE /* LedgerStreamClient.swift */,
 				F2E8FDC8C9DD1772F9943B8F /* LLMService.swift */,
 				8318D0791A1940E626D7A7ED /* ModelRouter.swift */,
 				5F7C910B6EF70385F75EC7BA /* PTYClient.swift */,
 				81B35BB2EF550D1169E8CFED /* SentinelAPIClient.swift */,
+				F6E914AE1A9757AE1CCF0849 /* VerifyAPIClient.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		543D8AB14C3728FF56C89EAC /* Foundry */ = {
+			isa = PBXGroup;
+			children = (
+				2DBADD02037E358509CA4563 /* FoundryConsoleView.swift */,
+			);
+			path = Foundry;
 			sourceTree = "<group>";
 		};
 		5B656A3896A9D4B8E38F5052 /* Audit */ = {
@@ -234,10 +268,18 @@
 		84EFB1F64934F1A83E45E3BF /* Reporting */ = {
 			isa = PBXGroup;
 			children = (
+				F59070AC06A493619616984F /* BountyReportView.swift */,
 				E654B5888ACF358B53174849 /* ReportView.swift */,
-				72507FD37EBD46AC963C6E14 /* BountyReportView.swift */,
 			);
 			path = Reporting;
+			sourceTree = "<group>";
+		};
+		8AE47DA980531B2AFBDB8851 /* Ghost */ = {
+			isa = PBXGroup;
+			children = (
+				8E9D7718A76376AF130F1182 /* GhostConsoleView.swift */,
+			);
+			path = Ghost;
 			sourceTree = "<group>";
 		};
 		9F4A1567420A88A2907C77A7 /* Pressure */ = {
@@ -296,12 +338,15 @@
 				5B656A3896A9D4B8E38F5052 /* Audit */,
 				47686AF82049D529E08F45D3 /* Components */,
 				7B41ED2CB39FF224E40A0163 /* Dashboard */,
+				543D8AB14C3728FF56C89EAC /* Foundry */,
+				8AE47DA980531B2AFBDB8851 /* Ghost */,
 				00D139BD55DE3822C0141BC0 /* Graph */,
 				CBB201D7DEF1757F9F9AF0CC /* Navigation */,
 				ABF3011118C3208D743C9393 /* Report */,
 				84EFB1F64934F1A83E45E3BF /* Reporting */,
 				5F3DA0D8B483B48446528192 /* Scan */,
 				7B599657E542D35BC783E8B2 /* Settings */,
+				2B95CA1995A2BE267BF78942 /* Verify */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -404,6 +449,7 @@
 				FD713260357E395BCDCB0682 /* BackendManager.swift in Sources */,
 				A69DC389458BE83CA02318CC /* BackendSettingsView.swift in Sources */,
 				1A516CAE139B1C4AE47F16B6 /* BackendState.swift in Sources */,
+				DBAB5790AC80CE69F7F453E4 /* BountyReportView.swift in Sources */,
 				250D8E25220B3AB535717493 /* ChatBubbleView.swift in Sources */,
 				C4EDBDE9C6812EFA33977B44 /* ChatView.swift in Sources */,
 				B2B02F24B8BBCE6B7103DF29 /* CortexStream.swift in Sources */,
@@ -412,7 +458,12 @@
 				41D448283BD2E10C0EEE06A0 /* ErrorClassifier.swift in Sources */,
 				A38739FF3B95F3B1102BA3C9 /* EventStreamClient.swift in Sources */,
 				3B4CFF3A62200F95F03F2377 /* FindingModels.swift in Sources */,
+				D0C5750A70133A74C61FED34 /* FoundryAPIClient.swift in Sources */,
+				8FAA39F14BE46EA50154291A /* FoundryConsoleView.swift in Sources */,
 				C94EFAA35A0D3B712FC57FB6 /* GenerateModels.swift in Sources */,
+				8226DC9F780680AC29BC0FDB /* GhostAPIClient.swift in Sources */,
+				C97C66E3ACF3313E004CBE13 /* GhostCaptureBrowser.swift in Sources */,
+				FAF5F3644A98AEA223E96513 /* GhostConsoleView.swift in Sources */,
 				C4EAE38493520E1B56033FEE /* GraphModels.swift in Sources */,
 				F1D02E19B9E5B252F227CA09 /* GraphRenderer.swift in Sources */,
 				0D5D3E555E784A70305E042C /* HelixAppState.swift in Sources */,
@@ -431,7 +482,6 @@
 				442083AD514DA033F1A9DC4E /* PressureShader.metal in Sources */,
 				65DA0F36B6B994075879AC8A /* ReportComposerView.swift in Sources */,
 				1B98978EE51F29E8B509AA59 /* ReportView.swift in Sources */,
-				75594BCD91644EB9B9031061 /* BountyReportView.swift in Sources */,
 				4A1FF7DA7509E33F640B70A5 /* RetryBackoff.swift in Sources */,
 				E75B45E5BB77A4B604D97732 /* ScanControlView.swift in Sources */,
 				AB8FD5D06E719FC5A93C0A44 /* ScanProjection.swift in Sources */,
@@ -444,6 +494,8 @@
 				8F1F1CC3866F00EBB302665E /* TierBadgeView.swift in Sources */,
 				AF8160EFA180077F6DF5E81E /* ToolMetadataModels.swift in Sources */,
 				B22F980AC2493CBC402F5BA2 /* ToolsBankView.swift in Sources */,
+				94A8F26426D3FD86CFDC31BD /* VerifyAPIClient.swift in Sources */,
+				15CD472F66509C7A4B858EA9 /* VerifyConsoleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ui/Sources/Services/BackendManager.swift
+++ b/ui/Sources/Services/BackendManager.swift
@@ -344,6 +344,24 @@ class BackendManager: ObservableObject {
             print("[BackendManager] Normalized SENTINEL_OLLAMA_URL to localhost (Docker legacy)")
         }
 
+        // Bug-bounty deconfliction header. HackerOne (and most programs)
+        // require an identifying header on ALL test traffic. If the operator
+        // has dropped their handle in ~/.sentinelforge/bb_handle, pass it to
+        // the backend so the Ghost proxy stamps every outbound request with
+        // it. The GUI is launched from Finder/Xcode and doesn't inherit the
+        // shell env, so we read the file explicitly. Empty/missing → header
+        // stays off (backend default).
+        let bbHandleURL = home
+            .appendingPathComponent(".sentinelforge")
+            .appendingPathComponent("bb_handle")
+        if let handle = try? String(contentsOf: bbHandleURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !handle.isEmpty
+        {
+            env["SENTINEL_GHOST_BB_VALUE"] = handle
+            print("[BackendManager] Deconfliction header enabled for handle: \(handle)")
+        }
+
         // Provide a boot manifest path for deterministic readiness diagnostics.
         let manifestDir =
             home
@@ -450,11 +468,19 @@ class BackendManager: ObservableObject {
             // Check health endpoint and parse readiness status
             let (reachable, status) = await checkBackendHealth(timeoutInterval: requestTimeout)
             if reachable, status == "ready" {
-                // TOKEN FRESHNESS CHECK:
-                // Ensure the token file has been updated SINCE we launched the process.
-                // This prevents race conditions where we connect using an old stale token
-                // before the new backend has overwritten it.
-                if isTokenFileFresh(since: launchTime) {
+                // TOKEN READINESS CHECK:
+                // The backend ADOPTS the existing on-disk token (precedence:
+                // env -> existing file -> generate) and only REWRITES the file
+                // when the token VALUE changes. So a fresh mtime proves "a new
+                // token was just written", but a stale mtime alongside an
+                // existing, valid token file is the normal steady state — the
+                // on-disk token is still exactly the one the backend is using.
+                //
+                // Gating on mtime alone made every launch after the first time
+                // out: _write_token_file() is idempotent, so the file is never
+                // rewritten and isTokenFileFresh() can never become true. Treat
+                // freshness as a positive signal, but accept any usable token.
+                if isTokenFileFresh(since: launchTime) || tokenFileIsUsable() {
                     await MainActor.run {
                         self.backendState = .ready
                         self.status = "Core Online"
@@ -465,7 +491,7 @@ class BackendManager: ObservableObject {
                     startHealthMonitor()
                     return
                 } else {
-                    print("[BackendManager] Health OK but Token Stale. Waiting for token write...")
+                    print("[BackendManager] Health OK but no usable token file yet. Waiting for token write...")
                 }
             } else if reachable, status == "starting" {
                 // Backend is reachable but still initializing - keep waiting
@@ -870,5 +896,19 @@ class BackendManager: ObservableObject {
         // Allow a small buffer (0.5s) for file system clock skews, but generally
         // the file modification must be AFTER the launch time.
         return modDate >= launchTime.addingTimeInterval(-0.5)
+    }
+
+    /// Whether a usable API token exists on disk. The backend adopts an
+    /// existing token file rather than overwriting it, so a valid (>=32 char,
+    /// url-safe) token here is the one the backend authenticates with —
+    /// regardless of whether the file was rewritten this launch. Mirrors the
+    /// backend's own sanity check in SentinelConfig.from_env().
+    private func tokenFileIsUsable() -> Bool {
+        let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".sentinelforge")
+            .appendingPathComponent("api_token")
+        guard let raw = try? String(contentsOf: tokenPath, encoding: .utf8) else { return false }
+        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.count >= 32 && token.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
     }
 }

--- a/ui/Sources/Services/GhostAPIClient.swift
+++ b/ui/Sources/Services/GhostAPIClient.swift
@@ -158,6 +158,65 @@ public struct GhostReplayResult: Codable {
     }
 }
 
+// MARK: - Cross-principal diff (G5)
+
+/// One step of a cross-principal replay: Alice's captured response vs Bob's.
+/// Mirror of a step entry in core/ghost/flow_diff.py FlowDiff.to_dict().
+public struct GhostCrossPrincipalStep: Codable, Identifiable, Equatable {
+    public let stepIndex: Int
+    public let method: String
+    public let url: String
+    public let aliceStatus: Int
+    public let bobStatus: Int
+    public let aliceBodySize: Int
+    public let bobBodySize: Int
+    public let signal: String
+    public let confidence: Double
+    public let rationale: String
+    public let isIdorSignal: Bool
+    public let aliceExcerpt: String?
+    public let bobExcerpt: String?
+
+    public var id: String { "\(stepIndex)-\(url)" }
+
+    enum CodingKeys: String, CodingKey {
+        case stepIndex = "step_index"
+        case method, url
+        case aliceStatus = "alice_status"
+        case bobStatus = "bob_status"
+        case aliceBodySize = "alice_body_size"
+        case bobBodySize = "bob_body_size"
+        case signal, confidence, rationale
+        case isIdorSignal = "is_idor_signal"
+        case aliceExcerpt = "alice_excerpt"
+        case bobExcerpt = "bob_excerpt"
+    }
+}
+
+/// Result of replaying a captured flow under a second identity (Bob).
+/// `idorStepCount` > 0 means Bob reached resources captured as Alice.
+public struct GhostCrossPrincipalDiff: Codable {
+    public let sourceFlowId: String
+    public let sourceFlowName: String
+    public let alicePersona: String
+    public let bobPersona: String
+    public let totalElapsedMs: Double
+    public let idorStepCount: Int
+    public let deniedStepCount: Int
+    public let stepFindings: [GhostCrossPrincipalStep]
+
+    enum CodingKeys: String, CodingKey {
+        case sourceFlowId = "source_flow_id"
+        case sourceFlowName = "source_flow_name"
+        case alicePersona = "alice_persona"
+        case bobPersona = "bob_persona"
+        case totalElapsedMs = "total_elapsed_ms"
+        case idorStepCount = "idor_step_count"
+        case deniedStepCount = "denied_step_count"
+        case stepFindings = "step_findings"
+    }
+}
+
 public struct GhostMutationSpec: Codable {
     public let stepIndex: Int
     public let mutation: String
@@ -175,32 +234,10 @@ public struct GhostMutationSpec: Codable {
     }
 }
 
-/// Minimal AnyCodable for opaque mutation params.
-public struct AnyCodable: Codable {
-    public let value: Any
-
-    public init(_ value: Any) { self.value = value }
-
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.singleValueContainer()
-        if let v = try? c.decode(Bool.self) { self.value = v; return }
-        if let v = try? c.decode(Int.self) { self.value = v; return }
-        if let v = try? c.decode(Double.self) { self.value = v; return }
-        if let v = try? c.decode(String.self) { self.value = v; return }
-        self.value = NSNull()
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var c = encoder.singleValueContainer()
-        switch value {
-        case let v as Bool: try c.encode(v)
-        case let v as Int: try c.encode(v)
-        case let v as Double: try c.encode(v)
-        case let v as String: try c.encode(v)
-        default: try c.encodeNil()
-        }
-    }
-}
+// NOTE: AnyCodable is defined once in Sources/Models/AnyCodable.swift
+// (type-erased Codable wrapper with nested array/dict support). The local
+// duplicate that used to live here collided with it as soon as this file
+// was added to the build target — removed in favor of the shared type.
 
 
 // MARK: - Errors
@@ -375,5 +412,30 @@ public final class GhostAPIClient {
         ]
         req.httpBody = try JSONSerialization.data(withJSONObject: body)
         return try await send(req, as: GhostReplayResult.self)
+    }
+
+    // MARK: cross-principal diff (G5)
+
+    /// Replay a captured flow (recorded as Alice) under a second identity
+    /// (Bob) and surface per-step cross-principal diffs. Bob is supplied as
+    /// raw headers/cookies — e.g. an `Authorization: Bearer …` token or a
+    /// session cookie — which REPLACE the captured credentials on replay.
+    public func crossPrincipalDiff(
+        flowId: String,
+        bobHeaders: [String: String] = [:],
+        bobCookies: [String: String] = [:]
+    ) async throws -> GhostCrossPrincipalDiff {
+        var req = authedRequest(
+            path: "/v1/ghost/flows/\(flowId)/diff", method: "POST"
+        )
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "alice_persona_name": "alice",
+            "bob_persona_name": "bob",
+            "bob_headers": bobHeaders,
+            "bob_cookies": bobCookies,
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return try await send(req, as: GhostCrossPrincipalDiff.self)
     }
 }

--- a/ui/Sources/Services/GhostCaptureBrowser.swift
+++ b/ui/Sources/Services/GhostCaptureBrowser.swift
@@ -1,0 +1,223 @@
+//
+//  GhostCaptureBrowser.swift
+//  SentinelForgeUI — Phase 4-UI
+//
+//  The "last mile" for Ghost Protocol: getting a browser's traffic to
+//  actually traverse the mitmproxy interceptor so it can be recorded.
+//
+//  Ghost is a PASSIVE proxy — it only sees traffic explicitly routed to
+//  127.0.0.1:<port>. Safari and WebKit-based browsers (incl. ChatGPT Atlas)
+//  honor only the GLOBAL system proxy, which is invasive and easy to leave
+//  dangling. Chromium-family browsers accept a per-instance `--proxy-server`
+//  flag plus an isolated `--user-data-dir`, so we can route exactly one
+//  throwaway browser window through Ghost without touching the system or the
+//  operator's real browsing. This is the same trick Burp/ZAP use for their
+//  embedded browsers.
+//
+//  HTTPS interception requires the mitmproxy CA to be trusted. On macOS,
+//  Chromium reads the System keychain, so a single `add-trusted-cert`
+//  (behind one admin prompt) makes every HTTPS site capturable.
+//
+
+import Foundation
+
+enum GhostCaptureBrowserError: LocalizedError {
+    case chromiumNotFound
+    case certPathMissing
+    case certTrustCancelled
+    case certTrustFailed(String)
+    case launchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .chromiumNotFound:
+            return "No Chromium-based browser found (Chrome/Chromium/Brave/Edge). "
+                + "Install one to use the isolated capture browser — WebKit browsers "
+                + "like Safari/Atlas can't be proxied per-window."
+        case .certPathMissing:
+            return "mitmproxy CA cert not found. Start the proxy at least once so it "
+                + "generates ~/.mitmproxy/mitmproxy-ca-cert.pem."
+        case .certTrustCancelled:
+            return "HTTPS cert trust was cancelled. HTTPS sites won't be captured until "
+                + "the mitmproxy CA is trusted."
+        case .certTrustFailed(let m):
+            return "Failed to trust the mitmproxy CA cert: \(m)"
+        case .launchFailed(let m):
+            return "Failed to launch the capture browser: \(m)"
+        }
+    }
+}
+
+/// Stateless helpers for the isolated capture browser. All process calls are
+/// blocking (`waitUntilExit`) and MUST be invoked off the main thread — the
+/// cert-trust step in particular puts up a modal admin dialog.
+enum GhostCaptureBrowser {
+
+    /// Where capture-browser profiles live.
+    static var profileBaseURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".sentinelforge")
+    }
+
+    /// A FRESH, unique Chromium profile per capture session.
+    ///
+    /// WHY NOT REUSE ONE PROFILE: that caused the dead-clicks bug. When an
+    /// earlier session ran through a broken proxy, Chrome cached the proxy's
+    /// HTML error pages *as* the site's JS libraries (jQuery etc.), and that
+    /// poison persisted into later, healthy sessions — so `$ is not defined`,
+    /// no handlers, a permanent blocking overlay. A fresh dir per launch
+    /// guarantees an empty cache AND a brand-new browser instance (so
+    /// `--proxy-server` always applies and never inherits a stale port). The
+    /// only cost is re-login per session, which you do as part of recording
+    /// anyway — and clean per-principal sessions are exactly what you want
+    /// for the cross-principal diff.
+    static func freshProfileURL() -> URL {
+        let stamp = Int(Date().timeIntervalSince1970 * 1000)
+        return profileBaseURL.appendingPathComponent("ghost-chrome-\(stamp)")
+    }
+
+    /// Remove capture profiles older than `maxAge` so they don't accumulate
+    /// on disk (each is a full Chromium profile). Best-effort.
+    static func reapOldProfiles(maxAge: TimeInterval = 6 * 3600) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: profileBaseURL,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+        let cutoff = Date().addingTimeInterval(-maxAge)
+        for url in entries where url.lastPathComponent.hasPrefix("ghost-chrome") {
+            let mod = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate
+            if let mod, mod < cutoff {
+                try? fm.removeItem(at: url)
+            }
+        }
+    }
+
+    /// First available Chromium-family browser, in preference order.
+    static func chromiumExecutableURL() -> URL? {
+        let candidates = [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ]
+        for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
+    }
+
+    /// Whether the mitmproxy CA cert is already present in the System
+    /// keychain. Presence after `add-trusted-cert -r trustRoot` implies it's
+    /// trusted as a root, so this doubles as a "do we need the admin prompt?"
+    /// check.
+    static func isCertTrusted() -> Bool {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        task.arguments = [
+            "find-certificate", "-c", "mitmproxy",
+            "/Library/Keychains/System.keychain",
+        ]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            return false
+        }
+        return task.terminationStatus == 0
+    }
+
+    /// Add the mitmproxy CA to the System keychain as a trusted root via a
+    /// single native admin prompt (osascript). Idempotent — re-adding an
+    /// existing cert is harmless. Throws `.certTrustCancelled` if the user
+    /// dismisses the password dialog.
+    static func trustCert(certPath: String?) throws {
+        guard let certPath, FileManager.default.fileExists(atPath: certPath) else {
+            throw GhostCaptureBrowserError.certPathMissing
+        }
+
+        // Build the privileged shell command, then wrap it for AppleScript.
+        // The cert path is single-quoted for the shell; the whole shell
+        // string is escaped for the AppleScript string literal.
+        let shellCmd = "security add-trusted-cert -d -r trustRoot "
+            + "-k /Library/Keychains/System.keychain '\(certPath)'"
+        let escaped = shellCmd
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let appleScript =
+            "do shell script \"\(escaped)\" with administrator privileges"
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", appleScript]
+        let errPipe = Pipe()
+        task.standardOutput = Pipe()
+        task.standardError = errPipe
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            throw GhostCaptureBrowserError.certTrustFailed(error.localizedDescription)
+        }
+
+        if task.terminationStatus != 0 {
+            let stderr = String(
+                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            // osascript returns -128 / "User canceled." when the admin dialog
+            // is dismissed — surface that as a distinct, non-alarming error.
+            if stderr.contains("User canceled") || stderr.contains("-128") {
+                throw GhostCaptureBrowserError.certTrustCancelled
+            }
+            throw GhostCaptureBrowserError.certTrustFailed(
+                stderr.isEmpty ? "exit code \(task.terminationStatus)" : stderr
+            )
+        }
+    }
+
+    /// Launch an isolated Chromium instance whose traffic is routed through
+    /// the Ghost proxy. The `--user-data-dir` forces a brand-new instance
+    /// (independent of any running Chrome) and quarantines capture state.
+    /// `<-loopback>` strips Chromium's implicit localhost bypass so that
+    /// loopback targets are captured too. Fire-and-forget: the browser keeps
+    /// running after this returns.
+    @discardableResult
+    static func launchCaptureBrowser(
+        proxyPort: Int,
+        startURL: String = "about:blank"
+    ) throws -> String {
+        guard let browser = chromiumExecutableURL() else {
+            throw GhostCaptureBrowserError.chromiumNotFound
+        }
+
+        // Fresh profile every launch → empty cache + brand-new instance.
+        reapOldProfiles()
+        let profile = freshProfileURL()
+        try? FileManager.default.createDirectory(
+            at: profile, withIntermediateDirectories: true
+        )
+
+        let task = Process()
+        task.executableURL = browser
+        task.arguments = [
+            "--proxy-server=127.0.0.1:\(proxyPort)",
+            "--proxy-bypass-list=<-loopback>",
+            "--user-data-dir=\(profile.path)",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--new-window",
+            startURL,
+        ]
+        do {
+            try task.run()
+        } catch {
+            throw GhostCaptureBrowserError.launchFailed(error.localizedDescription)
+        }
+        return browser.deletingPathExtension().lastPathComponent
+    }
+}

--- a/ui/Sources/Services/VerifyAPIClient.swift
+++ b/ui/Sources/Services/VerifyAPIClient.swift
@@ -173,13 +173,17 @@ public struct VerifyPromoteEntry: Codable, Identifiable, Equatable {
     }
 }
 
-public struct VerifyPromoteResult: Codable {
+public struct VerifyPromoteResult: Codable, Identifiable {
     public let findingId: String?
     public let targetUrl: String
     public let entryCount: Int
     public let stepsToReproduce: [String]
     public let placeholderLegend: [String: String]
     public let entries: [VerifyPromoteEntry]
+
+    // Identifiable conformance for `.sheet(item:)`. Computed (not stored) so it
+    // stays out of CodingKeys and doesn't affect decoding of the API response.
+    public var id: String { findingId ?? targetUrl }
 
     enum CodingKeys: String, CodingKey {
         case findingId = "finding_id"

--- a/ui/Sources/Views/Ghost/GhostConsoleView.swift
+++ b/ui/Sources/Views/Ghost/GhostConsoleView.swift
@@ -62,6 +62,21 @@ public struct GhostConsoleView: View {
                     result: result,
                     onClose: { vm.activeSheet = nil }
                 )
+            case .crossPrincipalInput(let flowId):
+                BobIdentitySheet(
+                    onRun: { auth, cookie in
+                        vm.activeSheet = nil
+                        vm.runCrossPrincipalDiff(
+                            flowId: flowId, bobAuth: auth, bobCookie: cookie
+                        )
+                    },
+                    onClose: { vm.activeSheet = nil }
+                )
+            case .crossPrincipalResult(let diff):
+                CrossPrincipalResultSheet(
+                    diff: diff,
+                    onClose: { vm.activeSheet = nil }
+                )
             }
         }
     }
@@ -117,13 +132,39 @@ public struct GhostConsoleView: View {
                 .tint(.green)
             }
 
-            if vm.status?.certAvailable == true, let p = vm.status?.certPath {
-                Button {
-                    NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: p)])
-                } label: {
-                    Label("CA Cert", systemImage: "lock.shield")
+            if vm.status?.running == true {
+                Button(action: { Task { await vm.launchCaptureBrowser() } }) {
+                    Label("Capture Browser", systemImage: "globe")
                 }
-                .help("Reveal the mitmproxy CA cert in Finder so you can install it in Keychain")
+                .buttonStyle(.bordered)
+                .tint(.cyberCyan)
+                .disabled(vm.isWorking)
+                .help("Open an isolated Chrome routed through Ghost and start recording. "
+                    + "Your normal browser and other apps are untouched. HTTPS needs the "
+                    + "mitmproxy cert trusted (you'll get one admin prompt the first time).")
+            }
+
+            if vm.status?.certAvailable == true, let p = vm.status?.certPath {
+                if vm.certTrusted {
+                    Button {
+                        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: p)])
+                    } label: {
+                        Label("Cert Trusted", systemImage: "checkmark.shield.fill")
+                    }
+                    .tint(.green)
+                    .help("The mitmproxy CA is trusted in your System keychain — HTTPS sites "
+                        + "capture cleanly. Click to reveal the cert in Finder.")
+                } else {
+                    Button {
+                        Task { await vm.trustCert() }
+                    } label: {
+                        Label("Trust HTTPS Cert", systemImage: "lock.shield")
+                    }
+                    .disabled(vm.isWorking)
+                    .help("Trust the mitmproxy CA in your System keychain (one admin prompt) so "
+                        + "HTTPS sites can be captured. Required once; replaces the old "
+                        + "reveal-in-Finder step.")
+                }
             }
         }
         .padding(.horizontal, 16)
@@ -162,7 +203,7 @@ public struct GhostConsoleView: View {
                     Text("No flows yet")
                         .font(.system(size: 12, design: .monospaced))
                         .foregroundColor(.white.opacity(0.45))
-                    Text("Start the proxy, configure your browser, then click 'New Recording' to capture a flow")
+                    Text("Start the proxy, then click 'Capture Browser' — it opens an isolated Chrome routed through Ghost and records as you browse. (Or name a flow and hit ⏺ to record manually.)")
                         .font(.system(size: 11))
                         .foregroundColor(.white.opacity(0.35))
                         .multilineTextAlignment(.center)
@@ -188,7 +229,10 @@ public struct GhostConsoleView: View {
                 TextField("flow name", text: $vm.newFlowName)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(size: 12, design: .monospaced))
-                    .disabled(vm.status?.running != true)
+                    // Always typeable — naming a flow before/while the proxy
+                    // spins up is harmless, and gating on the *polled* status
+                    // made the field dead until the next 3s refresh landed.
+                    // Only the record action itself requires a running proxy.
                 Button {
                     Task { await vm.startRecording() }
                 } label: {
@@ -292,11 +336,9 @@ public struct GhostConsoleView: View {
                         title: "Cross-Principal Diff",
                         systemImage: "person.2.fill",
                         color: .orange,
-                        help: "Replay this flow under a second persona and surface cross-principal IDORs (G5). Requires a Bob persona configured."
+                        help: "Replay this flow under a second identity (Bob) and surface cross-principal IDOR/BOLA (G5). You supply Bob's auth token or cookie."
                     ) {
-                        // G5 UI is its own work — placeholder for now,
-                        // operator can hit /v1/ghost/flows/{id}/diff from API.
-                        vm.errorMessage = "G5 diff UI is forthcoming — call the /v1/ghost/flows/\(flow.flowId)/diff endpoint directly with a Bob persona for now."
+                        vm.activeSheet = .crossPrincipalInput(flowId: flow.flowId)
                     }
                 }
 
@@ -382,15 +424,20 @@ final class GhostConsoleViewModel: ObservableObject {
     @Published var workingLabel: String = ""
     @Published var errorMessage: String?
     @Published var activeSheet: ActiveSheet?
+    @Published var certTrusted: Bool = false
 
     enum ActiveSheet: Identifiable {
         case proposals(GhostProposeResult)
         case replayResult(GhostReplayResult)
+        case crossPrincipalInput(flowId: String)
+        case crossPrincipalResult(GhostCrossPrincipalDiff)
 
         var id: String {
             switch self {
             case .proposals: return "proposals"
             case .replayResult: return "replay"
+            case .crossPrincipalInput: return "xpInput"
+            case .crossPrincipalResult: return "xpResult"
             }
         }
     }
@@ -425,6 +472,35 @@ final class GhostConsoleViewModel: ObservableObject {
         } catch {
             self.errorMessage = "Refresh failed: \(error.localizedDescription)"
         }
+
+        // Refresh CA-trust state only while still untrusted, so the poll
+        // loop stops spawning `security` once the cert is in the keychain.
+        if status?.certAvailable == true, !certTrusted {
+            let trusted = (try? await runOffMain { GhostCaptureBrowser.isCertTrusted() }) ?? false
+            self.certTrusted = trusted
+        }
+    }
+
+    /// Trust the mitmproxy CA in the System keychain (one admin prompt) so
+    /// HTTPS sites are interceptable. Idempotent — safe to click again.
+    func trustCert() async {
+        let certPath = status?.certPath
+        isWorking = true
+        workingLabel = "Trusting HTTPS cert…"
+        defer { isWorking = false; workingLabel = "" }
+        do {
+            try await runOffMain {
+                if !GhostCaptureBrowser.isCertTrusted() {
+                    try GhostCaptureBrowser.trustCert(certPath: certPath)
+                }
+            }
+            certTrusted = true
+            errorMessage = nil
+        } catch let e as GhostCaptureBrowserError {
+            errorMessage = e.errorDescription
+        } catch {
+            errorMessage = "Cert trust failed: \(error.localizedDescription)"
+        }
     }
 
     func startProxy() async {
@@ -449,6 +525,73 @@ final class GhostConsoleViewModel: ObservableObject {
         } catch {
             errorMessage = "Stop failed: \(error.localizedDescription)"
         }
+    }
+
+    /// One-click capture: ensure the mitmproxy CA is trusted (HTTPS), make
+    /// sure a recording is active so flows actually capture, then open an
+    /// isolated Chrome routed through the Ghost proxy. This is the "last mile"
+    /// that was previously missing — starting the proxy alone records nothing
+    /// because no browser was ever pointed at it.
+    func launchCaptureBrowser() async {
+        guard let port = status?.port, status?.running == true else {
+            errorMessage = "Start the proxy first (click Start)."
+            return
+        }
+        let certPath = status?.certPath
+        let hadActiveRecording = !(status?.activeRecordings.isEmpty ?? true)
+
+        isWorking = true
+        workingLabel = "Preparing capture browser…"
+        defer { isWorking = false; workingLabel = "" }
+
+        do {
+            // 1. Trust the mitmproxy CA so HTTPS sites are interceptable.
+            //    Off the main thread: the admin prompt is modal and blocking.
+            workingLabel = "Checking HTTPS cert…"
+            try await runOffMain {
+                if !GhostCaptureBrowser.isCertTrusted() {
+                    try GhostCaptureBrowser.trustCert(certPath: certPath)
+                }
+            }
+            certTrusted = true
+
+            // 2. Auto-start a recording if none is active — otherwise the
+            //    proxy sees traffic but the flows list stays empty.
+            if !hadActiveRecording {
+                try await client.startRecording("capture-\(Self.captureTimestamp())")
+            }
+
+            // 3. Launch the isolated, proxied browser.
+            workingLabel = "Opening capture browser…"
+            let browserName = try await runOffMain {
+                try GhostCaptureBrowser.launchCaptureBrowser(proxyPort: port)
+            }
+
+            errorMessage = nil
+            workingLabel = "\(browserName) launched — browse to capture"
+            await refresh()
+        } catch let e as GhostCaptureBrowserError {
+            errorMessage = e.errorDescription
+        } catch {
+            errorMessage = "Capture browser failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Run blocking work (Process calls, admin dialog) off the main actor so
+    /// the UI stays responsive while the capture browser spins up.
+    private func runOffMain<T>(_ work: @escaping () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { cont in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do { cont.resume(returning: try work()) }
+                catch { cont.resume(throwing: error) }
+            }
+        }
+    }
+
+    private static func captureTimestamp() -> String {
+        let f = DateFormatter()
+        f.dateFormat = "HHmmss"
+        return f.string(from: Date())
     }
 
     func startRecording() async {
@@ -504,6 +647,58 @@ final class GhostConsoleViewModel: ObservableObject {
             self.activeSheet = .replayResult(r)
         } catch {
             errorMessage = "Replay failed: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: cross-principal diff (G5)
+
+    func runCrossPrincipalDiff(flowId: String, bobAuth: String, bobCookie: String) {
+        Task { [weak self] in
+            await self?.executeCrossPrincipalDiff(
+                flowId: flowId, bobAuth: bobAuth, bobCookie: bobCookie
+            )
+        }
+    }
+
+    private func executeCrossPrincipalDiff(
+        flowId: String, bobAuth: String, bobCookie: String
+    ) async {
+        isWorking = true
+        workingLabel = "Replaying flow as Bob…"
+        defer { isWorking = false; workingLabel = "" }
+
+        // Bob's auth: accept a raw token or a full "Bearer …" value.
+        var headers: [String: String] = [:]
+        let auth = bobAuth.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !auth.isEmpty {
+            headers["Authorization"] = auth.lowercased().hasPrefix("bearer ")
+                ? auth : "Bearer \(auth)"
+        }
+        // Bob's cookies: parse a "k=v; k2=v2" string into a dict.
+        var cookies: [String: String] = [:]
+        let cookieStr = bobCookie.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cookieStr.isEmpty {
+            for pair in cookieStr.split(separator: ";") {
+                let kv = pair.split(separator: "=", maxSplits: 1).map {
+                    $0.trimmingCharacters(in: .whitespaces)
+                }
+                if kv.count == 2 { cookies[kv[0]] = kv[1] }
+            }
+        }
+
+        guard !headers.isEmpty || !cookies.isEmpty else {
+            errorMessage = "Provide Bob's auth token or a cookie to run the diff."
+            return
+        }
+
+        do {
+            let diff = try await client.crossPrincipalDiff(
+                flowId: flowId, bobHeaders: headers, bobCookies: cookies
+            )
+            self.activeSheet = .crossPrincipalResult(diff)
+            errorMessage = nil
+        } catch {
+            errorMessage = "Cross-principal diff failed: \(error.localizedDescription)"
         }
     }
 }
@@ -737,6 +932,206 @@ private struct StepDiffRow: View {
             ? Color.orange.opacity(0.10)
             : Color.white.opacity(0.04)
         )
+        .cornerRadius(6)
+    }
+}
+
+
+// MARK: - Cross-principal diff (G5): Bob identity input
+
+private struct BobIdentitySheet: View {
+    /// (authToken, cookieString)
+    let onRun: (String, String) -> Void
+    let onClose: () -> Void
+
+    @State private var auth: String = ""
+    @State private var cookie: String = ""
+
+    private var canRun: Bool {
+        !auth.trimmingCharacters(in: .whitespaces).isEmpty
+            || !cookie.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Cross-Principal Diff")
+                        .font(.system(size: 18, weight: .bold, design: .monospaced))
+                        .foregroundColor(.cyberCyan)
+                    Text("Replay this flow as a second identity (Bob)")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.6))
+                }
+                Spacer()
+                Button("Cancel") { onClose() }
+            }
+
+            Text("The captured flow plays as Alice. Paste Bob's session below — every request is re-issued as Bob, and any step where Bob receives Alice's data is flagged as IDOR/BOLA.")
+                .font(.system(size: 12))
+                .foregroundColor(.white.opacity(0.75))
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("BOB'S AUTH TOKEN")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.55))
+                TextField("Bearer eyJ…  (or just the raw token)", text: $auth)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                Text("Sent as the Authorization header, replacing Alice's.")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("BOB'S COOKIES (optional)")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.55))
+                TextField("session=…; other=…", text: $cookie)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                Text("For cookie-based auth. Format: name=value; name2=value2")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+
+            HStack {
+                Spacer()
+                Button { onRun(auth, cookie) } label: {
+                    Label("Run Diff", systemImage: "person.2.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+                .disabled(!canRun)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 560, minHeight: 340)
+        .background(Color(red: 0.05, green: 0.05, blue: 0.08))
+        .foregroundColor(.white)
+    }
+}
+
+
+// MARK: - Cross-principal diff (G5): result
+
+private struct CrossPrincipalResultSheet: View {
+    let diff: GhostCrossPrincipalDiff
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Cross-Principal Diff")
+                        .font(.system(size: 18, weight: .bold, design: .monospaced))
+                        .foregroundColor(.cyberCyan)
+                    Text("\(diff.alicePersona) → \(diff.bobPersona) · \(diff.sourceFlowName)")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.65))
+                }
+                Spacer()
+                Button("Close") { onClose() }
+            }
+            .padding()
+
+            Divider()
+
+            HStack(spacing: 24) {
+                stat("IDOR STEPS", "\(diff.idorStepCount)",
+                     color: diff.idorStepCount > 0 ? .red : .green)
+                stat("DENIED", "\(diff.deniedStepCount)", color: .green)
+                stat("STEPS", "\(diff.stepFindings.count)", color: .white)
+                stat("WALLCLOCK", "\(Int(diff.totalElapsedMs))ms", color: .white)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+
+            if diff.idorStepCount > 0 {
+                Text("⚠︎ Bob reached Alice's data — likely broken object-level authorization (IDOR/BOLA).")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.red)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
+
+            Divider()
+
+            if diff.stepFindings.isEmpty {
+                Spacer()
+                Text("No steps to compare.")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.5))
+                    .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 6) {
+                        ForEach(diff.stepFindings) { f in
+                            CrossPrincipalStepRow(finding: f)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+        .frame(minWidth: 820, minHeight: 600)
+        .background(Color(red: 0.05, green: 0.05, blue: 0.08))
+        .foregroundColor(.white)
+    }
+
+    private func stat(_ label: String, _ value: String, color: Color) -> some View {
+        VStack(alignment: .leading) {
+            Text(label)
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(.white.opacity(0.5))
+            Text(value)
+                .font(.system(size: 20, design: .monospaced))
+                .foregroundColor(color)
+        }
+    }
+}
+
+private struct CrossPrincipalStepRow: View {
+    let finding: GhostCrossPrincipalStep
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: finding.isIdorSignal
+                      ? "exclamationmark.triangle.fill" : "checkmark.shield.fill")
+                    .foregroundColor(finding.isIdorSignal ? .red : .green)
+                    .font(.system(size: 13))
+                Text("\(finding.method) \(finding.url)")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.9))
+                    .lineLimit(1)
+                Spacer()
+                Text(finding.signal)
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(finding.isIdorSignal
+                                ? Color.red.opacity(0.25) : Color.white.opacity(0.08))
+                    .cornerRadius(4)
+                Text(String(format: "%.0f%%", finding.confidence * 100))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(finding.isIdorSignal ? .red : .white.opacity(0.5))
+            }
+            Text("alice \(finding.aliceStatus)/\(finding.aliceBodySize)b  →  bob \(finding.bobStatus)/\(finding.bobBodySize)b")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(.white.opacity(0.55))
+            Text(finding.rationale)
+                .font(.system(size: 11))
+                .foregroundColor(.white.opacity(0.75))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(finding.isIdorSignal
+                    ? Color.red.opacity(0.10) : Color.white.opacity(0.04))
         .cornerRadius(6)
     }
 }


### PR DESCRIPTION
## Summary
Ghost Protocol was effectively unusable for live capture. This fixes the full chain end-to-end and turns the cross-principal (IDOR/BOLA) diff from an API-only stub into a working UI panel.

## Engine (`core/ghost`, `core/server`)
- **Lazarus is now passive** — no longer rewrites JS responses. It had been overwriting every in-bounds script with a truncated LLM pass (and, via an async bug, the repr of an un-awaited coroutine), which broke every site's click handlers. Route mining is read-only; byte-transparency is asserted by a regression test.
- **Capture-first ordering** — `request()` records the flow step before analysis, so a CAL/strategy error can't abort capture (it was recording 0 steps despite live traffic).
- **Removed per-request LLM strategy** from the proxy event loop (it threw unhandled task errors and disconnected upstreams under load).
- **Forced HTTP/1.1** for interception stability.
- **`stop()` now closes the proxyserver listener** (mitmproxy 12) before tearing down — fixes a socket leak that left zombie listeners accepting connections but resetting all upstream TLS (the real cause of dead pages). Covered by `test_ghost_proxy_lifecycle`.
- **Stable preferred proxy port (8787)** + **deconfliction header** (`SENTINEL_GHOST_BB_*`) stamping outbound requests for bug-bounty attribution.

## UI (`ui/Sources`)
- **`GhostCaptureBrowser`** — launches an isolated, proxied Chromium with a **fresh profile per session**. A reused profile cached the proxy's HTML error-pages *as* the site's JS libraries, poisoning later healthy sessions → `$ is not defined` → dead clicks.
- One-click **Trust HTTPS Cert**; flow-name field always typeable.
- **G5 Cross-Principal Diff panel** — enter Bob's token/cookie → replay the captured flow as Bob → IDOR findings table with confidence + rationale.
- `BackendManager` — readiness no longer hangs on the idempotent token file; passes the deconfliction handle from `~/.sentinelforge/bb_handle`.

## Verification
End-to-end against OWASP Juice Shop, driven through the actual app UI: the diff correctly flags the basket BOLA — Bob's token retrieves Alice's basket #6, byte-identical JSON, `identical-json` @ 90%.

## Tests
- `tests/integration/test_ghost_lazarus_integration.py` — fixed (were calling the async hook unawaited) + new byte-transparency regression.
- `tests/integration/test_ghost_proxy_lifecycle.py` — new; proves the proxy port is released on stop and re-bindable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Live capture now works end-to-end**: Ghost Protocol captures and analyzes JavaScript routes without breaking site interactivity. Lazarus engine converted to read-only analysis, preventing malformed responses that blocked click handlers. Verified against OWASP Juice Shop.

- **New GhostCaptureBrowser**: One-click isolated Chromium launcher with automatic HTTPS certificate trust flow. Fresh per-session profiles prevent cached proxy errors from poisoning subsequent captures.

- **G5 Cross-Principal Diff panel**: New UI feature for IDOR/BOLA detection. Enter alternate credentials (Bob's token/cookie), replay captured flows under that identity, and view findings table with confidence scores and rationale.

- **Stable proxy port (8787) with attribution**: Fixed port replaces ephemeral port chaos. Outbound requests stamped with deconfliction header for bug-bounty tracking across teams.

- **Fixed zombie listener socket leak**: Proxy shutdown now fully releases port and closes mitmproxy listeners before teardown. Eliminates TLS reset errors and dead pages when restarting proxy.

- **Reliable flow recording**: Capture now persists flow steps before running analysis. Errors in analysis no longer silently abort the recording—traffic is logged even if strategy execution fails.

- **Always-editable flow names**: Recording name field is now editable at all times (prior dead-field issue fixed).

- **Backend token idempotency**: BackendManager no longer hangs waiting for fresh token file. Accepts existing usable token and reads deconfliction handle from `~/.sentinelforge/bb_handle`.

## Risk & Rollback

**Primary risk**: Changes to proxy lifecycle (`async stop()`) and Lazarus passive processing could impact capture reliability or route extraction in edge cases.

**Safe rollback action**: Revert `core/ghost/proxy.py`, `core/ghost/lazarus.py`, and `core/server/routers/ghost.py` to previous versions; restart backend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->